### PR TITLE
Add Link header parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ python:
 - pypy
 sudo: false
 install:
-- pip install -r requirements.txt -r test-requirements.txt
+- pip install -r requirements.txt -r test-requirements.txt coveralls
 script:
 - nosetests
+after_success:
+- coveralls
 deploy:
   provider: pypi
   user: daveshawley

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ietfparse
 =========
 
-|Version| |Downloads| |Status| |License|
+|Version| |Downloads| |Status| |Coverage| |License|
 
 Wait... Why? What??
 -------------------
@@ -63,5 +63,7 @@ Ok... Where?
    :target: https://pypi.python.org/pypi/ietfparse
 .. |Status| image:: https://travis-ci.org/dave-shawley/ietfparse.svg
    :target: https://travis-ci.org/dave-shawley/ietfparse
+.. |Coverage| image:: https://coveralls.io/repos/dave-shawley/ietfparse/badge.svg
+   :target: https://coveralls.io/r/dave-shawley/ietfparse
 .. |License| image:: https://pypip.in/license/ietfparse/badge.svg
    :target: https://ietfparse.readthedocs.org/

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,11 +1,10 @@
 Changelog
 ---------
 
-* Next Release
+* 1.2.0 (19-Apr-2015)
 
-  - Added support for :rfc:`5988` ``Link`` headers.
-    This consists of ``headers.parse_link_header`` and
-    ``datastructures.LinkHeader``
+  - Added support for :rfc:`5988` ``Link`` headers.  This consists
+    of ``headers.parse_link_header`` and ``datastructures.LinkHeader``
 
 * 1.1.1 (10-Feb-2015)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+* Next Release
+
+  - Added support for :rfc:`5988` ``Link`` headers.
+    This consists of ``headers.parse_link_header`` and
+    ``datastructures.LinkHeader``
+
 * 1.1.1 (10-Feb-2015)
 
   - Removed ``setupext`` module since it was causing problems with

--- a/docs/header-parsing.rst
+++ b/docs/header-parsing.rst
@@ -52,3 +52,30 @@ to quality and specificity, selecting a matching content type is not as
 easy as traversing the list in order.  The full algorithm for selecting the
 most appropriate content type is described in :rfc:`7231` and is fully
 implemented by :func:`~ietfparse.algorithms.select_content_type`.
+
+Link
+----
+:func:`parse_link_header` parses an HTTP :mailheader:`Link` header as
+described in :rfc:`5988` into a sequence of
+:class:`ietfparse.datastructures.LinkHeader` instances.
+
+>>> from ietfparse import headers
+>>> parsed = headers.parse_link_header(
+...     '<http://example.com/TheBook/chapter2>; rel="previous"; '
+...     'title="previous chapter"')
+>>> parsed[0].target
+'http://example.com/TheBook/chapter2'
+>>> parsed[0].parameters
+[('rel', 'previous'), ('title', 'previous chapter')]
+
+Notice that the parameter values are returned as a list of name and value
+tuples.  This is by design and required by the RFC to support the
+``hreflang`` parameter as specified:
+
+   The "hreflang" parameter, when present, is a hint indicating what the
+   language of the result of dereferencing the link should be.  Note
+   that this is only a hint; for example, it does not override the
+   Content-Language header of a HTTP response obtained by actually
+   following the link.  Multiple "hreflang" parameters on a single link-
+   value indicate that multiple languages are available from the
+   indicated resource.

--- a/ietfparse/__init__.py
+++ b/ietfparse/__init__.py
@@ -1,2 +1,2 @@
-version_info = (1, 1, 1)
+version_info = (1, 2, 0)
 __version__ = '.'.join(str(x) for x in version_info)

--- a/ietfparse/_helpers.py
+++ b/ietfparse/_helpers.py
@@ -1,0 +1,98 @@
+from . import errors
+
+
+class ParameterParser(object):
+    """
+    Utility class to parse Link headers.
+
+    :param bool strict: controls whether parsing follows all of
+        the rules laid out in :rfc:`5988`
+
+    This class parses the parameters for a single :mailheader:`Link`
+    value.  It is used from within the guts of
+    :function:`ietfparse.headers.parse_link_header` and not readily
+    suited for other uses.  If *strict mode* is enabled, then the
+    following rules from the RFC are obeyed:
+
+    - section 5.3: when multiple "rel" attributes are present, then
+      the first one is chosen.  The remaining are omitted from the
+      value set.
+    - section 5.4: "there MUST NOT be more than one media parameter".
+      If more than one is present, then ``MalformedLinkValue`` is
+      raised.
+    - section 5.4: when multiple "type" attributes are present, then
+      the first one is chosen.  The remaining are omitted form the
+      value set.
+    - section 5.4: when multiple "title" attributes are present, then
+      the first one is chosen.  The remaining are omitted form the
+      value set.
+    - section 5.4: if both "title" and "title*" are present, then
+      "title*" is preferred.  The value of "title*" will be used
+      in all cases.
+    - section 5.4: "there MUST NOT be more than one type parameter".
+      If more than one is present, then ``MalformedLinkValue`` is
+      raised.
+
+    """
+
+    def __init__(self, strict=True):
+        self.strict = strict
+        self._values = []
+        self._rfc_values = {
+            'rel': None,
+            'media': None,
+            'type': None,
+            'title': None,
+            'title*': None,
+        }
+
+    def add_value(self, name, value):
+        """
+        Add a new value to the list.
+
+        :param str name: name of the value that is being parsed
+        :param str value: value that is being parsed
+        :raises ietfparse.errors.MalformedLinkValue:
+            if *strict mode* is enabled and a validation error
+            is detected
+
+        This method implements most of the validation mentioned in
+        sections 5.3 and 5.4 of :rfc:`5988`.  The ``_rfc_values``
+        dictionary contains the appropriate values for the attributes
+        that get special handling.  If *strict mode* is enabled, then
+        only values that are acceptable will be added to ``_values``.
+
+        """
+        try:
+            if self._rfc_values[name] is None:
+                self._rfc_values[name] = value
+            elif self.strict:
+                if name in ('media', 'type'):
+                    raise errors.MalformedLinkValue(
+                        'More than one {} parameter present'.format(name))
+                return
+        except KeyError:
+            pass
+
+        if self.strict and name in ('title', 'title*'):
+            return
+
+        self._values.append((name, value))
+
+    @property
+    def values(self):
+        """
+        The name/value mapping that was parsed.
+
+        :returns: a sequence of name/value pairs.
+
+        """
+        values = self._values[:]
+        if self.strict:
+            if self._rfc_values['title*']:
+                values.append(('title*', self._rfc_values['title*']))
+                if self._rfc_values['title']:
+                    values.append(('title', self._rfc_values['title*']))
+            elif self._rfc_values['title']:
+                values.append(('title', self._rfc_values['title']))
+        return values

--- a/ietfparse/compat/parse.py
+++ b/ietfparse/compat/parse.py
@@ -31,7 +31,7 @@ try:
         urlsplit,
         urlunsplit,
     )
-except ImportError:
+except ImportError:  # pragma: no cover, coverage with tox
     from urllib import (
         quote,
         splitnport,

--- a/ietfparse/datastructures.py
+++ b/ietfparse/datastructures.py
@@ -9,7 +9,6 @@ useful outside of a particular piece of functionality, it
 is fully fleshed out and ends up here.
 
 """
-import collections
 import functools
 
 
@@ -76,4 +75,29 @@ class ContentType(object):
         return self.content_type < other.content_type
 
 
-LinkHeader = collections.namedtuple('LinkHeader', 'target parameters')
+class LinkHeader(object):
+
+    """
+    Represents a single link within a ``Link`` header.
+
+    .. attribute:: target
+
+       The target URL of the link.  This may be a relative URL so
+       the caller may have to make the link absolute by resolving
+       it against a base URL as described in :rfc:`3986#section-5`.
+
+    .. attribute:: parameters
+
+       Possibly empty sequence of name and value pairs.  Parameters
+       are represented as a sequence since a single parameter may
+       occur more than once.
+
+    The :mailheader:`Link` header is specified by :rfc:`5988`.  It
+    is one of the methods used to represent HyperMedia links between
+    HTTP resources.
+
+    """
+
+    def __init__(self, target, parameters=None):
+        self.target = target
+        self.parameters = parameters or []

--- a/ietfparse/datastructures.py
+++ b/ietfparse/datastructures.py
@@ -9,6 +9,7 @@ useful outside of a particular piece of functionality, it
 is fully fleshed out and ends up here.
 
 """
+import collections
 import functools
 
 
@@ -73,3 +74,6 @@ class ContentType(object):
         if self.content_type == other.content_type:
             return self.content_subtype < other.content_subtype
         return self.content_type < other.content_type
+
+
+LinkHeader = collections.namedtuple('LinkHeader', 'target parameters')

--- a/ietfparse/errors.py
+++ b/ietfparse/errors.py
@@ -16,3 +16,8 @@ class RootException(Exception):
 class NoMatch(RootException):
     """No match was found when selecting a content type."""
     pass
+
+
+class MalformedLinkValue(RootException):
+    """Value specified is not a valid link header."""
+    pass

--- a/tests/link_header_tests.py
+++ b/tests/link_header_tests.py
@@ -2,7 +2,7 @@ import unittest
 
 from fluenttest import test_case
 
-from ietfparse import headers
+from ietfparse import errors, headers
 
 
 class WhenParsingSimpleLinkHeader(test_case.TestCase, unittest.TestCase):
@@ -66,11 +66,11 @@ class UglyParsingTests(unittest.TestCase):
 class WhenParsingMalformedLinkHeader(unittest.TestCase):
 
     def test_that_value_error_when_url_brackets_are_missing(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(errors.MalformedLinkValue):
             headers.parse_link_header('http://foo.com; rel=wrong')
 
     def test_that_first_semicolon_is_required(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(errors.MalformedLinkValue):
             headers.parse_link_header('<http://foo.com> rel="still wrong"')
 
     def test_that_first_rel_parameter_is_used(self):
@@ -81,7 +81,7 @@ class WhenParsingMalformedLinkHeader(unittest.TestCase):
         self.assertNotIn(('rel', 'ignored'), parsed[0].parameters)
 
     def test_that_multiple_media_parameters_are_rejected(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(errors.MalformedLinkValue):
             headers.parse_link_header('<first-link>; media=1; media=2')
 
     def test_that_first_title_parameter_is_used(self):
@@ -99,5 +99,5 @@ class WhenParsingMalformedLinkHeader(unittest.TestCase):
         self.assertNotIn(('title*', 'ignored'), parsed[0].parameters)
 
     def test_that_multiple_type_parameters_are_rejected(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(errors.MalformedLinkValue):
             headers.parse_link_header('<>; type=1; type=2')

--- a/tests/link_header_tests.py
+++ b/tests/link_header_tests.py
@@ -1,0 +1,71 @@
+import unittest
+
+from fluenttest import test_case
+
+from ietfparse import headers
+
+
+class WhenParsingSimpleLinkHeader(test_case.TestCase, unittest.TestCase):
+    @classmethod
+    def act(cls):
+        cls.parsed = headers.parse_link_header(
+            '<http://example.com/TheBook/chapter2>; rel="previous"; '
+            'title="previous chapter"')
+
+    def test_that_single_header_is_returned(self):
+        self.assertEqual(len(self.parsed), 1)
+
+    def test_that_target_iri_is_returned(self):
+        self.assertEqual(self.parsed[0].target,
+                         'http://example.com/TheBook/chapter2')
+
+    def test_that_rel_parameter_is_returned(self):
+        self.assertIn(('rel', 'previous'), self.parsed[0].parameters)
+
+    def test_that_title_parameter_is_returned(self):
+        self.assertIn(('title', 'previous chapter'), self.parsed[0].parameters)
+
+
+class MultipleLinkParsingTests(test_case.TestCase, unittest.TestCase):
+    @classmethod
+    def act(cls):
+        cls.parsed = headers.parse_link_header(
+            '<http://example.com/first>; rel=first;another=value,'
+            '<http://example.com/second>',
+        )
+
+    def test_that_both_links_are_returned(self):
+        self.assertEqual(self.parsed[0].target, 'http://example.com/first')
+        self.assertEqual(self.parsed[1].target, 'http://example.com/second')
+
+    def test_that_parameters_are_returned_when_present(self):
+        self.assertEqual(self.parsed[0].parameters,
+                         [('rel', 'first'), ('another', 'value')])
+
+    def test_that_empty_parameters_are_returned_when_appropriate(self):
+        self.assertEqual(self.parsed[1].parameters, [])
+
+
+class UglyParsingTests(unittest.TestCase):
+
+    def test_that_quoted_uris_can_contain_semicolons(self):
+        parsed = headers.parse_link_header('<http://host/matrix;param/>')
+        self.assertEqual(parsed[0].target, 'http://host/matrix;param/')
+
+
+class WhenParsingMalformedLinkHeader(unittest.TestCase):
+
+    def test_that_value_error_when_url_brackets_are_missing(self):
+        with self.assertRaises(ValueError):
+            headers.parse_link_header('http://foo.com; rel=wrong')
+
+    def test_that_first_semicolon_is_required(self):
+        with self.assertRaises(ValueError):
+            headers.parse_link_header('<http://foo.com> rel="still wrong"')
+
+    def test_that_first_rel_parameter_is_used(self):
+        # semantically malformed but handled appropriately
+        # see RFC5988 sec. 5.3
+        parsed = headers.parse_link_header('<>; rel=first; rel=ignored')
+        self.assertIn(('rel', 'first'), parsed[0].parameters)
+        self.assertNotIn(('rel', 'ignored'), parsed[0].parameters)

--- a/tests/link_header_tests.py
+++ b/tests/link_header_tests.py
@@ -52,6 +52,11 @@ class UglyParsingTests(unittest.TestCase):
         parsed = headers.parse_link_header('<http://host/matrix;param/>')
         self.assertEqual(parsed[0].target, 'http://host/matrix;param/')
 
+    def test_that_quoted_parameters_can_contain_commas(self):
+        parsed = headers.parse_link_header(
+            '<http://example/com>; rel="quoted, with comma", <1>')
+        self.assertEqual(parsed[0].parameters, [('rel', 'quoted, with comma')])
+
 
 class WhenParsingMalformedLinkHeader(unittest.TestCase):
 

--- a/tests/link_header_tests.py
+++ b/tests/link_header_tests.py
@@ -57,6 +57,12 @@ class UglyParsingTests(unittest.TestCase):
             '<http://example/com>; rel="quoted, with comma", <1>')
         self.assertEqual(parsed[0].parameters, [('rel', 'quoted, with comma')])
 
+    def test_that_quoted_parameters_can_contain_semicolons(self):
+        parsed = headers.parse_link_header(
+            '<http://example/com>; rel="quoted; with semicolon", <1>')
+        self.assertEqual(parsed[0].parameters,
+                         [('rel', 'quoted; with semicolon')])
+
     def test_that_title_star_overrides_title_parameter(self):
         parsed = headers.parse_link_header('<>; title=title; title*=title*')
         self.assertEqual(parsed[0].parameters,

--- a/tests/link_header_tests.py
+++ b/tests/link_header_tests.py
@@ -101,3 +101,12 @@ class WhenParsingMalformedLinkHeader(unittest.TestCase):
     def test_that_multiple_type_parameters_are_rejected(self):
         with self.assertRaises(errors.MalformedLinkValue):
             headers.parse_link_header('<>; type=1; type=2')
+
+    def test_that_semantic_tests_can_be_turned_off(self):
+        parsed = headers.parse_link_header(
+            '<multiple-titles>;title=one;title=two;title*=three;title*=four, '
+            '<multiple-rels>; rel=first; rel=second,'
+            '<multiple-medias>; media=one; media=two',
+            strict=False,
+        )
+        self.assertEqual(len(parsed), 3)


### PR DESCRIPTION
This PR adds the ability to parse [RFC5988](http://tools.ietf.org/html/rfc5988) `Link` headers.  The functionality consists of `headers.parse_link_header` which returns a list of header values.  See the documentation for more details.