### PR TITLE
Fix select content type

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+* 1.2.1 (25-May-2015)
+
+  - ``select_content_type`` claims to work with ``ContentType``
+    values but it was requiring the augmented ones returned from
+    ``parse_http_accept_header``.  IOW, the algorithm required
+    that the quality attribute exist.  RFC7231 states that missing
+    quality values are treated as 1.0.
+
+
 * 1.2.0 (19-Apr-2015)
 
   - Added support for :rfc:`5988` ``Link`` headers.  This consists

--- a/ietfparse/__init__.py
+++ b/ietfparse/__init__.py
@@ -1,2 +1,2 @@
-version_info = (1, 2, 0)
+version_info = (1, 2, 1)
 __version__ = '.'.join(str(x) for x in version_info)

--- a/ietfparse/algorithms.py
+++ b/ietfparse/algorithms.py
@@ -126,12 +126,15 @@ def select_content_type(requested, available):
                     else:
                         self.parameter_distance += 1
 
+    def extract_quality(obj):
+        return getattr(obj, 'quality', 1.0)
+
     matches = []
-    for pattern in sorted(requested, key=attrgetter('quality'), reverse=True):
+    for pattern in sorted(requested, key=extract_quality, reverse=True):
         for candidate in sorted(available):
             if _content_type_matches(candidate, pattern):
                 if candidate == pattern:  # exact match!!!
-                    if pattern.quality == 0.0:
+                    if extract_quality(pattern) == 0.0:
                         raise errors.NoMatch  # quality of 0 means NO
                     return candidate, pattern
                 matches.append(Match(candidate, pattern))

--- a/tests/algorithm_tests.py
+++ b/tests/algorithm_tests.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ietfparse import algorithms, errors, headers
+from ietfparse import algorithms, datastructures, errors, headers
 
 
 class ContentNegotiationTestCase(unittest.TestCase):
@@ -109,3 +109,19 @@ class WhenUsingRfc7231Examples(ContentNegotiationTestCase):
             'text/html;level=3', 'text/html;level=3',
             matching_pattern='text/html',
         )
+
+
+class WhenSelectingWithRawContentTypes(unittest.TestCase):
+
+    def test_that_raw_content_type_has_highest_quality(self):
+        selected, matched = algorithms.select_content_type(
+            [
+                datastructures.ContentType('type', 'preferred')
+            ],
+            [
+                datastructures.ContentType('type', 'acceptable'),
+                datastructures.ContentType('type', 'almost-perfect'),
+                datastructures.ContentType('type', 'preferred'),
+            ],
+        )
+        self.assertEqual(selected.content_subtype, 'preferred')


### PR DESCRIPTION
This PR makes `algorithms.select_content_type` actually work with raw `ContentType` instances.