### PR TITLE
Parse Accept-Charset headers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ietfparse
 =========
 
-|Version| |Downloads| |Status| |Coverage| |License|
+|Version| |ReadTheDocs| |Travis| |Coverage| |CodeClimate|
 
 Wait... Why? What??
 -------------------
@@ -57,13 +57,13 @@ Ok... Where?
 | Issues        | https://github.com/dave-shawley/ietfparse       |
 +---------------+-------------------------------------------------+
 
-.. |Version| image:: https://pypip.in/version/ietfparse/badge.svg
-   :target: https://pypi.python.org/pypi/ietfparse
-.. |Downloads| image:: https://pypip.in/d/ietfparse/badge.svg
-   :target: https://pypi.python.org/pypi/ietfparse
-.. |Status| image:: https://travis-ci.org/dave-shawley/ietfparse.svg
-   :target: https://travis-ci.org/dave-shawley/ietfparse
+.. |CodeClimate| image:: https://codeclimate.com/github/dave-shawley/ietfparse/badges/gpa.svg
+   :target: https://codeclimate.com/github/dave-shawley/ietfparse/
 .. |Coverage| image:: https://coveralls.io/repos/dave-shawley/ietfparse/badge.svg
    :target: https://coveralls.io/r/dave-shawley/ietfparse
-.. |License| image:: https://pypip.in/license/ietfparse/badge.svg
+.. |ReadTheDocs| image:: https://readthedocs.org/projects/ietfparse/badge/
    :target: https://ietfparse.readthedocs.org/
+.. |Travis| image:: https://travis-ci.org/dave-shawley/ietfparse.svg
+   :target: https://travis-ci.org/dave-shawley/ietfparse
+.. |Version| image:: https://badge.fury.io/py/ietfparse.svg
+   :target: http://badge.fury.io/py/ietfparse

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,26 +1,28 @@
 Changelog
 ---------
 
+.. py:currentmodule:: ietfparse
+
 * Next Release
 
-  - Added ``headers.parse_list_header`` which parses generic comma-
+  - Added :func:`headers.parse_list_header` which parses generic comma-
     separated list headers with support for quoted parts.
-  - Added ``headers.parse_accept_charset`` which parses an HTTP
-    ``Accept-Charset`` header into a sorted list.
+  - Added :func:`headers.parse_accept_charset` which parses an HTTP
+    `Accept-Charset`_ header into a sorted list.
 
 * 1.2.1 (25-May-2015)
 
-  - ``select_content_type`` claims to work with ``ContentType``
-    values but it was requiring the augmented ones returned from
-    ``parse_http_accept_header``.  IOW, the algorithm required
-    that the quality attribute exist.  RFC7231 states that missing
-    quality values are treated as 1.0.
-
+  - :func:`algorithms.select_content_type` claims to work with
+    :class:`datastructures.ContentType`` values but it was requiring
+    the augmented ones returned from  :func:`algorithms.parse_http_accept_header`.
+    IOW, the algorithm required that the quality attribute exist.
+    :rfc:`7231#section-5.3.1` states that missing quality values are
+    treated as 1.0.
 
 * 1.2.0 (19-Apr-2015)
 
   - Added support for :rfc:`5988` ``Link`` headers.  This consists
-    of ``headers.parse_link_header`` and ``datastructures.LinkHeader``
+    of :func:`headers.parse_link_header` and :class:`datastructures.LinkHeader`
 
 * 1.1.1 (10-Feb-2015)
 
@@ -29,14 +31,16 @@ Changelog
 
 * 1.1.0 (26-Oct-2014)
 
-  - Added ``algorithms.rewrite_url``
+  - Added :func:`algorithms.rewrite_url`
 
 * 1.0.0 (21-Sep-2014)
 
   - Initial implementation containing the following functionality:
-      - ``algorithms.select_content_type``
-      - ``datastructures.ContentType``
-      - ``errors.NoMatch``
-      - ``errors.RootException``
-      - ``headers.parse_content_type``
-      - ``headers.parse_http_accept_header``
+      - :func:`algorithms.select_content_type`
+      - :class:`datastructures.ContentType`
+      - :class:`errors.NoMatch`
+      - :class:`errors.RootException`
+      - :func:`headers.parse_content_type`
+      - :func:`headers.parse_http_accept_header`
+
+.. _Accept-Charset: https://tools.ietf.org/html/rfc7231#section-5.3.3

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ Changelog
   - Added :func:`headers.parse_accept_charset` which parses an HTTP
     `Accept-Charset`_ header into a sorted list.
 
-* 1.2.1 (25-May-2015)
+* `1.2.1`_ (25-May-2015)
 
   - :func:`algorithms.select_content_type` claims to work with
     :class:`datastructures.ContentType`` values but it was requiring
@@ -19,17 +19,17 @@ Changelog
     :rfc:`7231#section-5.3.1` states that missing quality values are
     treated as 1.0.
 
-* 1.2.0 (19-Apr-2015)
+* `1.2.0`_ (19-Apr-2015)
 
   - Added support for :rfc:`5988` ``Link`` headers.  This consists
     of :func:`headers.parse_link_header` and :class:`datastructures.LinkHeader`
 
-* 1.1.1 (10-Feb-2015)
+* `1.1.1`_ (10-Feb-2015)
 
   - Removed ``setupext`` module since it was causing problems with
     source distributions.
 
-* 1.1.0 (26-Oct-2014)
+* `1.1.0`_ (26-Oct-2014)
 
   - Added :func:`algorithms.rewrite_url`
 
@@ -44,3 +44,8 @@ Changelog
       - :func:`headers.parse_http_accept_header`
 
 .. _Accept-Charset: https://tools.ietf.org/html/rfc7231#section-5.3.3
+
+.. _1.1.0: https://github.com/dave-shawley/ietfparse/compare/1.0.0...1.1.0
+.. _1.1.1: https://github.com/dave-shawley/ietfparse/compare/1.1.0...1.1.1
+.. _1.2.0: https://github.com/dave-shawley/ietfparse/compare/1.1.1...1.2.0
+.. _1.2.1: https://github.com/dave-shawley/ietfparse/compare/1.2.0...1.2.1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,8 @@ Changelog
 
   - Added ``headers.parse_list_header`` which parses generic comma-
     separated list headers with support for quoted parts.
+  - Added ``headers.parse_accept_charset`` which parses an HTTP
+    ``Accept-Charset`` header into a sorted list.
 
 * 1.2.1 (25-May-2015)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+* Next Release
+
+  - Added ``headers.parse_list_header`` which parses generic comma-
+    separated list headers with support for quoted parts.
+
 * 1.2.1 (25-May-2015)
 
   - ``select_content_type`` claims to work with ``ContentType``

--- a/docs/header-parsing.rst
+++ b/docs/header-parsing.rst
@@ -79,3 +79,32 @@ tuples.  This is by design and required by the RFC to support the
    following the link.  Multiple "hreflang" parameters on a single link-
    value indicate that multiple languages are available from the
    indicated resource.
+
+Accept-Charset
+--------------
+:func:`parse_accept_charset` parses the HTTP :mailheader:`Accept-Charset`
+header into a sorted sequence of character set identifiers.  Character set
+identifiers are simple tokens with an optional quality value that is the
+strength of the preference from most preferred (1.0) to rejection (0.0).
+After the header is parsed and sorted, the quality values are removed and
+the token list is returned.
+
+>>> from ietfparse import headers
+>>> charsets = headers.parse_accept_charset('latin1;q=0.5, utf-8;q=1.0, '
+...                                         'us-ascii;q=0.1, ebcdic;q=0.0')
+['utf-8', 'latin1', 'us-ascii', 'ebcdic']
+
+The wildcard character set if present, will be sorted towards the end of the
+list.  If both a wildcard and rejected values are present, then the wildcard
+will occur *before* the rejected values.
+
+>>> from ietfparse import headers
+>>> charsets = headers.parse_accept_charset('acceptable, rejected;q=0, *')
+['acceptable', '*', 'rejected']
+
+.. note::
+
+   The only attribute that is allowed to be specified per the RFC is the
+   quality value.  If additional parameters are included, they are not
+   included in the response from this function.  More specifically, the
+   returned list contains only the character set strings.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,5 +7,6 @@
    header-parsing
    header-processing
    reference
+   rfcs
    contributing
    changelog

--- a/docs/rfcs.rst
+++ b/docs/rfcs.rst
@@ -1,0 +1,58 @@
+Relevant RFCs
+=============
+
+`RFC-2045`_
+-----------
+- :class:`ietfparse.datastructures.ContentType` is an abstraction of
+  the :mailheader:`Content-Type` header described in :rfc:`2045` and
+  fully specified in section `5.1`_.
+
+`RFC-3986`_
+-----------
+- :func:`ietfparse.algorithms.rewrite_url` implements encoding and
+  parsing per :rfc:`3986`.
+
+`RFC-5980`_
+-----------
+- :func:`ietfparse.algorithms.rewrite_url` encodes hostnames according
+  to :rfc:`5980` for the schemes identified by
+  :data:`~ietfparse.algorithms.IDNA_SCHEMES`.  Encoding can also be
+  forced using the ``encode_with_idna`` keyword parameter.
+
+`RFC-5988`_
+-----------
+- :func:`ietfparse.headers.parse_link_header` parses a :mailheader:`Link`
+  HTTP header.
+- :func:`ietfparse.datastructures.LinkHeader` represents a :mailheader:`Link`
+  HTTP header.
+
+`RFC-7231`_
+-----------
+- :func:`ietfparse.algorithms.select_content_type` implements proactive
+  content negotiation as described in sections `3.4.1`_ and `5.3`_ of
+  :rfc:`7231`
+- :func:`ietfparse.headers.parse_accept_charset` parses a
+  :mailheader:`Accept-Charset` value as described in section `5.3.3`_.
+- :func:`ietfparse.headers.parse_http_accept_header` parses a
+  :mailheader:`Accept` value as described in section `5.3.2`_.
+- :func:`ietfparse.headers.parse_list_header` parses just about any of
+  the comma-separated lists from :rfc:`7231`.  It doesn't provide any
+  logic other than parsing the header though.
+- :func:`ietfparse.headers.parse_parameter_list` parses the ``key=value``
+  portions common to many header values.
+
+
+.. _RFC-2045: https://tools.ietf.org/html/rfc2045
+.. _5.1: https://tools.ietf.org/html/rfc2045#section-5.1
+
+.. _RFC-3986: https://tools.ietf.org/html/rfc3986
+
+.. _RFC-5980: https://tools.ietf.org/html/rfc5980
+
+.. _RFC-5988: https://tools.ietf.org/html/rfc5988
+
+.. _RFC-7231: https://tools.ietf.org/html/rfc7231
+.. _3.4.1: https://tools.ietf.org/html/rfc7231#section-3.4.1
+.. _5.3: https://tools.ietf.org/html/rfc7231#section-5.3
+.. _5.3.2: https://tools.ietf.org/html/rfc7231#section-5.3.2
+.. _5.3.3: https://tools.ietf.org/html/rfc7231#section-5.3.3

--- a/ietfparse/headers.py
+++ b/ietfparse/headers.py
@@ -2,10 +2,11 @@
 Functions for parsing headers.
 
 - :func:`.parse_content_type`: parse a ``Content-Type`` value
-- :func:`.parse_http_accept_header`: parse an ``Accept`` style header
+- :func:`.parse_http_accept_header`: parse an ``Accept`` header
 - :func:`.parse_link_header`: parse a :rfc:`5988` ``Link`` header
 - :func:`.parse_list_header`: parse a comma-separated list that is
   present in so many headers
+- :func:`.parse_accept_charset`: parse a ``Accept-Charset`` header
 
 This module also defines classes that might be of some use outside
 of the module.  They are not designed for direct usage unless otherwise
@@ -38,10 +39,12 @@ def parse_parameter_list(parameter_list, normalized_parameter_values=True):
     """
     parameters = []
     for param in parameter_list:
-        name, value = param.strip().split('=')
-        if normalized_parameter_values:
-            value = value.lower()
-        parameters.append((name, value.strip('"').strip()))
+        param = param.strip()
+        if param:
+            name, value = param.split('=')
+            if normalized_parameter_values:
+                value = value.lower()
+            parameters.append((name, value.strip('"').strip()))
     return parameters
 
 
@@ -174,3 +177,46 @@ def parse_list_header(value):
         value = ''.join([left, match.replace(',', '\000'), right])
     return [x.strip().strip('"').replace('\000', ',')
             for x in value.split(',')]
+
+
+def parse_accept_charset(header_value):
+    """
+    Parse the ``Accept-Charset`` header into a sorted list.
+
+    :param str header_value: header value to parse
+
+    :return: list of character sets sorted from highest to lowest
+        priority
+
+    The `Accept-Charset`_ header is a list of character set names with
+    optional *quality* values.  The quality value indicates the strength
+    of the preference where 1.0 is a strong preference and less than 0.001
+    is outright rejection by the client.
+
+    .. note::
+
+       Character sets that are rejected by setting the quality value
+       to less than 0.001.  If a wildcard is included in the header,
+       then it will appear **BEFORE** values that are rejected.
+
+    .. _Accept-Charset: https://tools.ietf.org/html/rfc7231#section-5.3.3
+
+    """
+    found_wildcard = False
+    values, rejected_values = [], []
+    for raw_str in parse_list_header(header_value):
+        charset, _, parameter_str = raw_str.replace(' ', '').partition(';')
+        if charset == '*':
+            found_wildcard = True
+            continue
+        params = dict(parse_parameter_list(parameter_str.split(';')))
+        quality = float(params.pop('q', '1.0'))
+        if quality < 0.001:
+            rejected_values.append(charset)
+        else:
+            values.append((quality, charset))
+    parsed = [value[1] for value in reversed(sorted(values))]
+    if found_wildcard:
+        parsed.append('*')
+    parsed.extend(rejected_values)
+    return parsed

--- a/tests/generic_parsing_tests.py
+++ b/tests/generic_parsing_tests.py
@@ -1,0 +1,20 @@
+import unittest
+
+from ietfparse import headers
+
+
+class WhenParsingListHeader(unittest.TestCase):
+
+    def test_that_elements_are_whitespace_normalized(self):
+        self.assertEqual(
+            headers.parse_list_header('one, two,three    ,four,five'),
+            ['one', 'two', 'three', 'four', 'five'])
+
+    def test_that_quotes_are_removed(self):
+        self.assertEqual(headers.parse_list_header('"quoted value"'),
+                         ['quoted value'])
+
+    def test_that_quoted_commas_are_retained(self):
+        self.assertEqual(
+            headers.parse_list_header('first, "comma ->,<- here", last'),
+            ['first', 'comma ->,<- here', 'last'])

--- a/tests/parse_accept_header_tests.py
+++ b/tests/parse_accept_header_tests.py
@@ -50,3 +50,35 @@ class WhenParsingHttpAcceptHeaderWithoutQualities(
 
     def test_that_least_specific_wildcard_is_least_preferred(self):
         self.assertEqual(self.parsed[3], datastructures.ContentType('*', '*'))
+
+
+class WhenParsingAcceptCharsetHeader(unittest.TestCase):
+
+    def test_that_simple_wildcard_parses(self):
+        self.assertEqual(headers.parse_accept_charset('*'), ['*'])
+
+    def test_that_response_sorted_by_quality(self):
+        self.assertEqual(
+            headers.parse_accept_charset('us-ascii;q=0.1, latin1;q=0.5,'
+                                         'utf-8; q=1.0'),
+            ['utf-8', 'latin1', 'us-ascii'],
+        )
+
+    def test_that_unspecified_quality_is_treated_as_highest(self):
+        self.assertEqual(
+            headers.parse_accept_charset('us-ascii;q=0.1,utf-8,latin1;q=0.8'),
+            ['utf-8', 'latin1', 'us-ascii'],
+        )
+
+    def test_that_wildcard_sorts_before_rejected_character_sets(self):
+        self.assertEqual(
+            headers.parse_accept_charset('latin1;q=0.5, utf-8;q=1.0,'
+                                         'us-ascii;q=0.1, ebcdic;q=0, *'),
+            ['utf-8', 'latin1', 'us-ascii', '*', 'ebcdic'],
+        )
+
+    def test_that_quality_below_0_001_is_rejected(self):
+        self.assertEqual(
+            headers.parse_accept_charset('acceptable, rejected;q=0.0009, *'),
+            ['acceptable', '*', 'rejected'],
+        )


### PR DESCRIPTION
This PR adds the `parse_accept_charset` function to the headers module.  It will parse and sort the HTTP `Accept-Charset` header per [RFC-7231](https://tools.ietf.org/html/rfc7231).