### PR TITLE
Add Accept-Encoding && Accept-Language

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,4 +2,5 @@ People that have contributed
 ============================
 
 - Dave Shawley <daveshawley@gmail.com>
+- Gavin M. Roy <gavinmroy@gmail.com>
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,13 @@ Changelog
 
 .. py:currentmodule:: ietfparse
 
+* `1.4.0`_ (15-Oct-2016)
+
+  - Added :func:`headers.parse_accept_encoding` which parses HTTP `Accept-Encoding`_
+    header values into a list.
+  - Added :func:`headers.parse_accept_language` which parses HTTP `Accept-Language`_
+    header values into a list.
+
 * `1.3.0`_ (11-Aug-2016)
 
   - Added :func:`headers.parse_cache_control` which parses HTTP `Cache-Control`_
@@ -59,6 +66,8 @@ Changelog
       - :func:`headers.parse_http_accept_header`
 
 .. _Accept-Charset: https://tools.ietf.org/html/rfc7231#section-5.3.3
+.. _Accept-Encoding: https://tools.ietf.org/html/rfc7231#section-5.3.4
+.. _Accept-Language: https://tools.ietf.org/html/rfc7231#section-5.3.5
 .. _Cache-Control: https://tools.ietf.org/html/rfc7231#section-5.2
 
 .. _1.1.0: https://github.com/dave-shawley/ietfparse/compare/1.0.0...1.1.0
@@ -67,3 +76,4 @@ Changelog
 .. _1.2.1: https://github.com/dave-shawley/ietfparse/compare/1.2.0...1.2.1
 .. _1.2.2: https://github.com/dave-shawley/ietfparse/compare/1.2.1...1.2.2
 .. _1.3.0: https://github.com/dave-shawley/ietfparse/compare/1.2.2...1.3.0
+.. _1.4.0: https://github.com/dave-shawley/ietfparse/compare/1.3.0...1.4.0

--- a/docs/header-parsing.rst
+++ b/docs/header-parsing.rst
@@ -5,7 +5,7 @@ Header Parsing
 
 Accept
 ------
-:func:`parse_accept` parses the HTTP :mailheader:`Accept` header
+:func:`parse_accept` parses the HTTP :httpheader:`Accept` header
 into a sorted list of :class:`ietfparse.datastructures.ContentType` instances.
 The list is sorted according to the specified quality values. Elements with
 the same quality value are ordered with the *most-specific* value first.  The
@@ -27,7 +27,7 @@ implemented by :func:`~ietfparse.algorithms.select_content_type`.
 
 Accept-Charset
 --------------
-:func:`parse_accept_charset` parses the HTTP :mailheader:`Accept-Charset`
+:func:`parse_accept_charset` parses the HTTP :httpheader:`Accept-Charset`
 header into a sorted sequence of character set identifiers.  Character set
 identifiers are simple tokens with an optional quality value that is the
 strength of the preference from most preferred (1.0) to rejection (0.0).
@@ -44,8 +44,62 @@ list.  If both a wildcard and rejected values are present, then the wildcard
 will occur *before* the rejected values.
 
 >>> from ietfparse import headers
->>> charsets = headers.parse_accept_charset('acceptable, rejected;q=0, *')
+>>> headers.parse_accept_charset('acceptable, rejected;q=0, *')
 ['acceptable', '*', 'rejected']
+
+.. note::
+
+   The only attribute that is allowed to be specified per the RFC is the
+   quality value.  If additional parameters are included, they are not
+   included in the response from this function.  More specifically, the
+   returned list contains only the character set strings.
+
+Accept-Encoding
+---------------
+:func:`parse_accept_encoding` parses the HTTP :httpheader:`Accept-Encoding`
+header into a sorted sequence of encodings.  Encodings are simple tokens
+with an optional quality value that is the strength of the preference from
+most preferred (1.0) to rejection (0.0). After the header is parsed and sorted,
+the quality values are removed and the token list is returned.
+
+>>> from ietfparse import headers
+>>> headers.parse_accept_encoding('snappy, compress;q=0.7, gzip;q=0.8')
+['snappy', 'gzip', 'compress']
+
+The wildcard character set if present, will be sorted towards the end of the
+list.  If both a wildcard and rejected values are present, then the wildcard
+will occur *before* the rejected values.
+
+>>> from ietfparse import headers
+>>> headers.parse_accept_encoding('compress, snappy;q=0, *')
+['compress', '*', 'snappy']
+
+.. note::
+
+   The only attribute that is allowed to be specified per the RFC is the
+   quality value.  If additional parameters are included, they are not
+   included in the response from this function.  More specifically, the
+   returned list contains only the character set strings.
+
+Accept-Language
+---------------
+:func:`parse_accept_language` parses the HTTP :httpheader:`Accept-Language`
+header into a sorted sequence of languages.  Languages are simple tokens
+with an optional quality value that is the strength of the preference from
+most preferred (1.0) to rejection (0.0). After the header is parsed and sorted,
+the quality values are removed and the token list is returned.
+
+>>> from ietfparse import headers
+>>> headers.parse_accept_language('da, en;q=0.7, en-gb;q=0.8')
+['de', 'en-gb', 'en']
+
+The wildcard character set if present, will be sorted towards the end of the
+list.  If both a wildcard and rejected values are present, then the wildcard
+will occur *before* the rejected values.
+
+>>> from ietfparse import headers
+>>> headers.parse_accept_language('es-es, en;q=0, *')
+['es-es', '*', 'en']
 
 .. note::
 

--- a/docs/header-parsing.rst
+++ b/docs/header-parsing.rst
@@ -5,7 +5,7 @@ Header Parsing
 
 Accept
 ------
-:func:`parse_accept` parses the HTTP :httpheader:`Accept` header
+:func:`parse_accept` parses the HTTP :http:header:`Accept` header
 into a sorted list of :class:`ietfparse.datastructures.ContentType` instances.
 The list is sorted according to the specified quality values. Elements with
 the same quality value are ordered with the *most-specific* value first.  The
@@ -27,7 +27,7 @@ implemented by :func:`~ietfparse.algorithms.select_content_type`.
 
 Accept-Charset
 --------------
-:func:`parse_accept_charset` parses the HTTP :httpheader:`Accept-Charset`
+:func:`parse_accept_charset` parses the HTTP :http:header:`Accept-Charset`
 header into a sorted sequence of character set identifiers.  Character set
 identifiers are simple tokens with an optional quality value that is the
 strength of the preference from most preferred (1.0) to rejection (0.0).
@@ -56,7 +56,7 @@ will occur *before* the rejected values.
 
 Accept-Encoding
 ---------------
-:func:`parse_accept_encoding` parses the HTTP :httpheader:`Accept-Encoding`
+:func:`parse_accept_encoding` parses the HTTP :http:header:`Accept-Encoding`
 header into a sorted sequence of encodings.  Encodings are simple tokens
 with an optional quality value that is the strength of the preference from
 most preferred (1.0) to rejection (0.0). After the header is parsed and sorted,
@@ -83,7 +83,7 @@ will occur *before* the rejected values.
 
 Accept-Language
 ---------------
-:func:`parse_accept_language` parses the HTTP :httpheader:`Accept-Language`
+:func:`parse_accept_language` parses the HTTP :http:header:`Accept-Language`
 header into a sorted sequence of languages.  Languages are simple tokens
 with an optional quality value that is the strength of the preference from
 most preferred (1.0) to rejection (0.0). After the header is parsed and sorted,
@@ -122,7 +122,7 @@ in the dictionary with a value of ``True`` if set.
 
 Content-Type
 ------------
-:func:`parse_content_type` parses a MIME or HTTP :mailheader:`Content-Type`
+:func:`parse_content_type` parses a MIME or HTTP :http:header:`Content-Type`
 header into an object that exposes the structured data.
 
 >>> from ietfparse import headers
@@ -150,7 +150,7 @@ normalized as well.
 
 Link
 ----
-:func:`parse_link` parses an HTTP :mailheader:`Link` header as
+:func:`parse_link` parses an HTTP :http:header:`Link` header as
 described in :rfc:`5988` into a sequence of
 :class:`ietfparse.datastructures.LinkHeader` instances.
 

--- a/ietfparse/__init__.py
+++ b/ietfparse/__init__.py
@@ -1,2 +1,2 @@
-version_info = (1, 3, 0)
+version_info = (1, 4, 0)
 __version__ = '.'.join(str(x) for x in version_info)

--- a/tests/headers_parse_accept_tests.py
+++ b/tests/headers_parse_accept_tests.py
@@ -54,6 +54,8 @@ class WhenParsingHttpAcceptHeaderWithoutQualities(
 
 class WhenParsingAcceptCharsetHeader(unittest.TestCase):
 
+    # Final example in http://tools.ietf.org/html/rfc7231#section-5.3.3
+
     def test_that_simple_wildcard_parses(self):
         self.assertEqual(headers.parse_accept_charset('*'), ['*'])
 
@@ -81,4 +83,70 @@ class WhenParsingAcceptCharsetHeader(unittest.TestCase):
         self.assertEqual(
             headers.parse_accept_charset('acceptable, rejected;q=0.0009, *'),
             ['acceptable', '*', 'rejected'],
+        )
+
+
+class WhenParsingAcceptEncodingHeader(unittest.TestCase):
+
+    # Final example in http://tools.ietf.org/html/rfc7231#section-5.3.4
+
+    def test_that_simple_wildcard_parses(self):
+        self.assertEqual(headers.parse_accept_encoding('*'), ['*'])
+
+    def test_that_response_sorted_by_quality(self):
+        self.assertEqual(
+            headers.parse_accept_encoding('compress, gzip;q=0.8, bzip;q=0.7'),
+            ['compress', 'gzip', 'bzip']
+        )
+
+    def test_that_unspecified_quality_is_treated_as_highest(self):
+        self.assertEqual(
+            headers.parse_accept_encoding('snappy;q=0.1,gzip,bzip;q=0.8'),
+            ['gzip', 'bzip', 'snappy']
+        )
+
+    def test_that_wildcard_sorts_before_rejected_character_sets(self):
+        self.assertEqual(
+            headers.parse_accept_encoding('gzip;q=0.5, compress;q=1.0,'
+                                          'bzip;q=0.1, snappy;q=0, *'),
+            ['compress', 'gzip', 'bzip', '*', 'snappy']
+        )
+
+    def test_that_quality_below_0_001_is_rejected(self):
+        self.assertEqual(
+            headers.parse_accept_encoding('bzip, gzip;q=0.0009, *'),
+            ['bzip', '*', 'gzip']
+        )
+
+
+class WhenParsingAcceptLanguageHeader(unittest.TestCase):
+
+    # Final example in http://tools.ietf.org/html/rfc7231#section-5.3.5
+
+    def test_that_simple_wildcard_parses(self):
+        self.assertEqual(headers.parse_accept_language('*'), ['*'])
+
+    def test_that_response_sorted_by_quality(self):
+        self.assertEqual(
+            headers.parse_accept_language('de, en-gb;q=0.8, en;q=0.7'),
+            ['de', 'en-gb', 'en']
+        )
+
+    def test_that_unspecified_quality_is_treated_as_highest(self):
+        self.assertEqual(
+            headers.parse_accept_language('en-gb;q=0.1,de,en;q=0.8'),
+            ['de', 'en', 'en-gb']
+        )
+
+    def test_that_wildcard_sorts_before_rejected_character_sets(self):
+        self.assertEqual(
+            headers.parse_accept_language('es;q=0.5, es-mx;q=1.0,'
+                                          'es-es;q=0.1, es-pr;q=0, *'),
+            ['es-mx', 'es', 'es-es', '*', 'es-pr']
+        )
+
+    def test_that_quality_below_0_001_is_rejected(self):
+        self.assertEqual(
+            headers.parse_accept_language('aa, bb;q=0.0009, *'),
+            ['aa', '*', 'bb']
         )


### PR DESCRIPTION
Update docs to use :http:header: instead of :mailheader: as :mailheader: is deprecated, see https://pythonhosted.org/sphinxcontrib-httpdomain/#role-http:header