### PR TITLE
Preserve ordering in accept list parsing.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014, Dave Shawley
+Copyright (c) 2014-2017, Dave Shawley
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Ok... Where?
 +---------------+-------------------------------------------------+
 | Download      | https://pypi.python.org/pypi/ietfparse          |
 +---------------+-------------------------------------------------+
-| Documentation | http://ietfparse.readthedocs.org/en/latest      |
+| Documentation | http://ietfparse.readthedocs.io/en/latest       |
 +---------------+-------------------------------------------------+
 | Issues        | https://github.com/dave-shawley/ietfparse       |
 +---------------+-------------------------------------------------+
@@ -61,7 +61,7 @@ Ok... Where?
    :target: https://codeclimate.com/github/dave-shawley/ietfparse/
 .. |Coverage| image:: https://coveralls.io/repos/dave-shawley/ietfparse/badge.svg
    :target: https://coveralls.io/r/dave-shawley/ietfparse
-.. |ReadTheDocs| image:: https://readthedocs.org/projects/ietfparse/badge/
+.. |ReadTheDocs| image:: https://readthedocs.org/projects/ietfparse/badge/?version=stable
    :target: https://ietfparse.readthedocs.org/
 .. |Travis| image:: https://travis-ci.org/dave-shawley/ietfparse.svg
    :target: https://travis-ci.org/dave-shawley/ietfparse

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,8 +3,8 @@ Changelog
 
 .. py:currentmodule:: ietfparse
 
-`Next Release`_
----------------
+`1.4.3`_ (30-Oct-2017)
+----------------------
 - Change parsing of qualified lists to retain the initial ordering whenever
   possible.  The algorithm prefers explicit highest quality (1.0) preferences
   over inferred highest quality preferences.  It also retains the initial
@@ -99,4 +99,5 @@ Changelog
 .. _1.4.0: https://github.com/dave-shawley/ietfparse/compare/1.3.0...1.4.0
 .. _1.4.1: https://github.com/dave-shawley/ietfparse/compare/1.4.0...1.4.1
 .. _1.4.2: https://github.com/dave-shawley/ietfparse/compare/1.4.1...1.4.2
-.. _Next Release: https://github.com/dave-shawley/ietfparse/compare/1.4.2...head
+.. _1.4.3: https://github.com/dave-shawley/ietfparse/compare/1.4.2...1.4.3
+.. _Next Release: https://github.com/dave-shawley/ietfparse/compare/1.4.3...head

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,15 @@ Changelog
 
 .. py:currentmodule:: ietfparse
 
+* `Next Release`_
+
+  - Change parsing of qualified lists to retain the initial ordering whenever
+    possible.  The algorithm prefers explicit highest quality (1.0) preferences
+    over inferred highest quality preferences.  It also retains the initial
+    ordering in the presence of multiple highest quality matches.  This affects
+    :func:`headers.parse_accept_charset`, :func:`headers.parse_accept_encoding`,
+    and :func:`headers.parse_accept_language`.
+
 * `1.4.2`_ (04-Jul-2017)
 
   - Add formatting of HTTP `Link`_ header using ``str(header)``.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,88 +1,88 @@
 Changelog
----------
+=========
 
 .. py:currentmodule:: ietfparse
 
-* `Next Release`_
+`Next Release`_
+---------------
+- Change parsing of qualified lists to retain the initial ordering whenever
+  possible.  The algorithm prefers explicit highest quality (1.0) preferences
+  over inferred highest quality preferences.  It also retains the initial
+  ordering in the presence of multiple highest quality matches.  This affects
+  :func:`headers.parse_accept_charset`, :func:`headers.parse_accept_encoding`,
+  and :func:`headers.parse_accept_language`.
 
-  - Change parsing of qualified lists to retain the initial ordering whenever
-    possible.  The algorithm prefers explicit highest quality (1.0) preferences
-    over inferred highest quality preferences.  It also retains the initial
-    ordering in the presence of multiple highest quality matches.  This affects
-    :func:`headers.parse_accept_charset`, :func:`headers.parse_accept_encoding`,
-    and :func:`headers.parse_accept_language`.
+`1.4.2`_ (04-Jul-2017)
+----------------------
+- Add formatting of HTTP `Link`_ header using ``str(header)``.
 
-* `1.4.2`_ (04-Jul-2017)
+`1.4.1`_ (03-Apr-2017)
+----------------------
+- Add some documentation about exceptions raised during header parsing.
 
-  - Add formatting of HTTP `Link`_ header using ``str(header)``.
+`1.4.0`_ (18-Oct-2016)
+----------------------
+- Fixed parsing of lists like ``max-age=5, x-foo="prune"``.  The previous
+  versions incorrectly produced ``['max-age=5', 'x-foo="prune']``.
+- Added :func:`headers.parse_accept_encoding` which parses HTTP `Accept-Encoding`_
+  header values into a list.
+- Added :func:`headers.parse_accept_language` which parses HTTP `Accept-Language`_
+  header values into a list.
 
-* `1.4.1`_ (03-Apr-2017)
-
-  - Add some documentation about exceptions raised during header parsing.
-
-* `1.4.0`_ (18-Oct-2016)
-
-  - Fixed parsing of lists like ``max-age=5, x-foo="prune"``.  The previous
-    versions incorrectly produced ``['max-age=5', 'x-foo="prune']``.
-  - Added :func:`headers.parse_accept_encoding` which parses HTTP `Accept-Encoding`_
-    header values into a list.
-  - Added :func:`headers.parse_accept_language` which parses HTTP `Accept-Language`_
-    header values into a list.
-
-* `1.3.0`_ (11-Aug-2016)
-
-  - Added :func:`headers.parse_cache_control` which parses HTTP `Cache-Control`_
-    header values into a dictionary.
-  - Renamed :func:`headers.parse_http_accept_header` to :func:`headers.parse_accept`,
-    adding a wrapper function that raises a deprecation function when invoking
-    :func:`headers.parse_http_accept_header`.
-  - Renamed :func:`headers.parse_link_header` to :func:`headers.parse_link`,
-    adding a wrapper function that raises a deprecation function when invoking
-    :func:`headers.parse_link_header`.
-  - Renamed :func:`headers.parse_list_header` to :func:`headers.parse_list`,
-    adding a wrapper function that raises a deprecation function when invoking
-    :func:`headers.parse_list_header`.
+`1.3.0`_ (11-Aug-2016)
+----------------------
+- Added :func:`headers.parse_cache_control` which parses HTTP `Cache-Control`_
+  header values into a dictionary.
+- Renamed :func:`headers.parse_http_accept_header` to :func:`headers.parse_accept`,
+  adding a wrapper function that raises a deprecation function when invoking
+  :func:`headers.parse_http_accept_header`.
+- Renamed :func:`headers.parse_link_header` to :func:`headers.parse_link`,
+  adding a wrapper function that raises a deprecation function when invoking
+  :func:`headers.parse_link_header`.
+- Renamed :func:`headers.parse_list_header` to :func:`headers.parse_list`,
+  adding a wrapper function that raises a deprecation function when invoking
+  :func:`headers.parse_list_header`.
 
 
-* `1.2.2`_ (27-May-2015)
+`1.2.2`_ (27-May-2015)
+----------------------
+- Added :func:`headers.parse_list_header` which parses generic comma-
+  separated list headers with support for quoted parts.
+- Added :func:`headers.parse_accept_charset` which parses an HTTP
+  `Accept-Charset`_ header into a sorted list.
 
-  - Added :func:`headers.parse_list_header` which parses generic comma-
-    separated list headers with support for quoted parts.
-  - Added :func:`headers.parse_accept_charset` which parses an HTTP
-    `Accept-Charset`_ header into a sorted list.
+`1.2.1`_ (25-May-2015)
+----------------------
+- :func:`algorithms.select_content_type` claims to work with
+  :class:`datastructures.ContentType`` values but it was requiring
+  the augmented ones returned from  :func:`algorithms.parse_http_accept_header`.
+  IOW, the algorithm required that the quality attribute exist.
+  :rfc:`7231#section-5.3.1` states that missing quality values are
+  treated as 1.0.
 
-* `1.2.1`_ (25-May-2015)
+`1.2.0`_ (19-Apr-2015)
+----------------------
+- Added support for :rfc:`5988` ``Link`` headers.  This consists
+  of :func:`headers.parse_link_header` and :class:`datastructures.LinkHeader`
 
-  - :func:`algorithms.select_content_type` claims to work with
-    :class:`datastructures.ContentType`` values but it was requiring
-    the augmented ones returned from  :func:`algorithms.parse_http_accept_header`.
-    IOW, the algorithm required that the quality attribute exist.
-    :rfc:`7231#section-5.3.1` states that missing quality values are
-    treated as 1.0.
+`1.1.1`_ (10-Feb-2015)
+----------------------
+- Removed ``setupext`` module since it was causing problems with
+  source distributions.
 
-* `1.2.0`_ (19-Apr-2015)
+`1.1.0`_ (26-Oct-2014)
+----------------------
+- Added :func:`algorithms.rewrite_url`
 
-  - Added support for :rfc:`5988` ``Link`` headers.  This consists
-    of :func:`headers.parse_link_header` and :class:`datastructures.LinkHeader`
-
-* `1.1.1`_ (10-Feb-2015)
-
-  - Removed ``setupext`` module since it was causing problems with
-    source distributions.
-
-* `1.1.0`_ (26-Oct-2014)
-
-  - Added :func:`algorithms.rewrite_url`
-
-* 1.0.0 (21-Sep-2014)
-
-  - Initial implementation containing the following functionality:
-      - :func:`algorithms.select_content_type`
-      - :class:`datastructures.ContentType`
-      - :class:`errors.NoMatch`
-      - :class:`errors.RootException`
-      - :func:`headers.parse_content_type`
-      - :func:`headers.parse_http_accept_header`
+1.0.0 (21-Sep-2014)
+-------------------
+- Initial implementation containing the following functionality:
+  - :func:`algorithms.select_content_type`
+  - :class:`datastructures.ContentType`
+  - :class:`errors.NoMatch`
+  - :class:`errors.RootException`
+  - :func:`headers.parse_content_type`
+  - :func:`headers.parse_http_accept_header`
 
 .. _Accept-Charset: https://tools.ietf.org/html/rfc7231#section-5.3.3
 .. _Accept-Encoding: https://tools.ietf.org/html/rfc7231#section-5.3.4

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@ from ietfparse import __version__, version_info
 
 
 project = 'ietfparse'
-copyright = '2014, Dave Shawley'
+copyright = '2014-2017, Dave Shawley'
 version = __version__
 release = '.'.join(str(x) for x in version_info[:2])
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,13 +3,13 @@
 
 import sphinx_rtd_theme
 
-from ietfparse import __version__, version_info
+import ietfparse
 
 
 project = 'ietfparse'
 copyright = '2014-2017, Dave Shawley'
-version = __version__
-release = '.'.join(str(x) for x in version_info[:2])
+version = ietfparse.version
+release = '.'.join(str(x) for x in ietfparse.version_info[:2])
 
 needs_sphinx = '1.0'
 extensions = [

--- a/ietfparse/__init__.py
+++ b/ietfparse/__init__.py
@@ -1,2 +1,2 @@
 version_info = (1, 4, 2)
-__version__ = '.'.join(str(x) for x in version_info)
+version = '.'.join(str(x) for x in version_info)

--- a/ietfparse/__init__.py
+++ b/ietfparse/__init__.py
@@ -1,2 +1,2 @@
-version_info = (1, 4, 2)
+version_info = (1, 4, 3)
 version = '.'.join(str(x) for x in version_info)

--- a/ietfparse/headers.py
+++ b/ietfparse/headers.py
@@ -316,18 +316,24 @@ def _parse_qualified_list(value):
     """
     found_wildcard = False
     values, rejected_values = [], []
-    for raw_str in parse_list(value):
+    parsed = parse_list(value)
+    default = float(len(parsed) + 1)
+    highest = default + 1.0
+    for raw_str in parsed:
         charset, _, parameter_str = raw_str.replace(' ', '').partition(';')
         if charset == '*':
             found_wildcard = True
             continue
         params = dict(_parse_parameter_list(parameter_str.split(';')))
-        quality = float(params.pop('q', '1.0'))
+        quality = float(params.pop('q', default))
         if quality < 0.001:
             rejected_values.append(charset)
+        elif quality == 1.0:
+            values.append((highest + default, charset))
         else:
             values.append((quality, charset))
-    parsed = [value[1] for value in reversed(sorted(values))]
+        default -= 1.0
+    parsed = [value[1] for value in sorted(values, reverse=True)]
     if found_wildcard:
         parsed.append('*')
     parsed.extend(rejected_values)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 
 import setuptools
 
-from ietfparse import __version__
+from ietfparse import version
 
 
 def read_requirements_file(name):
@@ -37,7 +37,7 @@ with codecs.open('README.rst', 'rb', encoding='utf-8') as file_obj:
 
 setuptools.setup(
     name='ietfparse',
-    version=__version__,
+    version=version,
     author='Dave Shawley',
     author_email='daveshawley@gmail.com',
     url='http://github.com/dave-shawley/ietfparse',
@@ -56,7 +56,7 @@ setuptools.setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Text Processing',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
 coverage>=3.7,<4
-fluent-test>=3.0,<4
 nose>=1.3,<2

--- a/tests/datastructure_tests.py
+++ b/tests/datastructure_tests.py
@@ -1,15 +1,14 @@
 import unittest
 
-from fluenttest import test_case
-
 from ietfparse.datastructures import ContentType
 
 
-class WhenCreatingContentType(test_case.TestCase, unittest.TestCase):
-    @classmethod
-    def act(cls):
-        cls.value = ContentType(
-            'ContentType', ' SubType ', parameters={'Key': 'Value'})
+class WhenCreatingContentType(unittest.TestCase):
+
+    def setUp(self):
+        super(WhenCreatingContentType, self).setUp()
+        self.value = ContentType('ContentType', ' SubType ',
+                                 parameters={'Key': 'Value'})
 
     def should_normalize_primary_type(self):
         self.assertEqual(self.value.content_type, 'contenttype')
@@ -21,23 +20,18 @@ class WhenCreatingContentType(test_case.TestCase, unittest.TestCase):
         self.assertEqual(self.value.parameters['key'], 'Value')
 
 
-class WhenConvertingSimpleContentTypeToStr(
-        test_case.TestCase, unittest.TestCase):
-
-    @classmethod
-    def act(cls):
-        cls.returned = str(ContentType('primary', 'subtype'))
+class WhenConvertingSimpleContentTypeToStr(unittest.TestCase):
 
     def test_only_contains_type_information(self):
-        self.assertEqual(self.returned, 'primary/subtype')
+        self.assertEqual(str(ContentType('primary', 'subtype')),
+                         'primary/subtype')
 
 
-class WhenConvertingContentTypeWithParametersToStr(
-        test_case.TestCase, unittest.TestCase):
+class WhenConvertingContentTypeWithParametersToStr(unittest.TestCase):
 
-    @classmethod
-    def act(cls):
-        cls.returned = str(ContentType(
+    def setUp(self):
+        super(WhenConvertingContentTypeWithParametersToStr, self).setUp()
+        self.returned = str(ContentType(
             'primary', 'subtype', {'one': '1', 'two': '2', 'three': 3}))
 
     def test_starts_with_primary_type(self):

--- a/tests/headers_cache_control_tests.py
+++ b/tests/headers_cache_control_tests.py
@@ -1,15 +1,13 @@
 import unittest
 
-from fluenttest import test_case
-
 from ietfparse import headers
 
 
-class WhenParsingCacheControl(test_case.TestCase, unittest.TestCase):
+class WhenParsingCacheControl(unittest.TestCase):
 
-    @classmethod
-    def act(cls):
-        cls.parsed = headers.parse_cache_control(
+    def setUp(self):
+        super(WhenParsingCacheControl, self).setUp()
+        self.parsed = headers.parse_cache_control(
             'public, must-revalidate, max-age=100, min-fresh=20, '
             'community="UCI", x-token=" foo bar "')
 

--- a/tests/headers_content_type_tests.py
+++ b/tests/headers_content_type_tests.py
@@ -1,15 +1,13 @@
 import unittest
 
-from fluenttest import test_case
-
 from ietfparse import datastructures, headers
 
 
-class WhenParsingSimpleContentType(test_case.TestCase, unittest.TestCase):
+class WhenParsingSimpleContentType(unittest.TestCase):
 
-    @classmethod
-    def act(cls):
-        cls.parsed = headers.parse_content_type(
+    def setUp(self):
+        super(WhenParsingSimpleContentType, self).setUp()
+        self.parsed = headers.parse_content_type(
             'text/plain', normalize_parameter_values=False)
 
     def test_that_type_is_parsed(self):
@@ -22,11 +20,11 @@ class WhenParsingSimpleContentType(test_case.TestCase, unittest.TestCase):
         self.assertEqual(self.parsed.parameters, {})
 
 
-class WhenParsingComplexContentType(test_case.TestCase, unittest.TestCase):
+class WhenParsingComplexContentType(unittest.TestCase):
 
-    @classmethod
-    def act(cls):
-        cls.parsed = headers.parse_content_type(
+    def setUp(self):
+        super(WhenParsingComplexContentType, self).setUp()
+        self.parsed = headers.parse_content_type(
             'message/HTTP; version=2.0 (someday); MsgType="Request"',
             normalize_parameter_values=False)
 

--- a/tests/headers_link_tests.py
+++ b/tests/headers_link_tests.py
@@ -1,14 +1,13 @@
 import unittest
 
-from fluenttest import test_case
-
 from ietfparse import errors, headers
 
 
-class WhenParsingSimpleLinkHeader(test_case.TestCase, unittest.TestCase):
-    @classmethod
-    def act(cls):
-        cls.parsed = headers.parse_link(
+class WhenParsingSimpleLinkHeader(unittest.TestCase):
+
+    def setUp(self):
+        super(WhenParsingSimpleLinkHeader, self).setUp()
+        self.parsed = headers.parse_link(
             '<http://example.com/TheBook/chapter2>; rel="previous"; '
             'title="previous chapter"')
 
@@ -26,10 +25,11 @@ class WhenParsingSimpleLinkHeader(test_case.TestCase, unittest.TestCase):
         self.assertIn(('title', 'previous chapter'), self.parsed[0].parameters)
 
 
-class MultipleLinkParsingTests(test_case.TestCase, unittest.TestCase):
-    @classmethod
-    def act(cls):
-        cls.parsed = headers.parse_link(
+class MultipleLinkParsingTests(unittest.TestCase):
+
+    def setUp(self):
+        super(MultipleLinkParsingTests, self).setUp()
+        self.parsed = headers.parse_link(
             '<http://example.com/first>; rel=first;another=value,'
             '<http://example.com/second>',
         )

--- a/tests/headers_parse_accept_tests.py
+++ b/tests/headers_parse_accept_tests.py
@@ -1,55 +1,57 @@
 import unittest
 
-from fluenttest import test_case
-
 from ietfparse import datastructures, headers
 
 
-class WhenParsingSimpleHttpAcceptHeader(test_case.TestCase, unittest.TestCase):
+class WhenParsingSimpleHttpAcceptHeader(unittest.TestCase):
 
     # First example from http://tools.ietf.org/html/rfc7231#section-5.3.2
-
-    @classmethod
-    def act(cls):
-        cls.parsed = headers.parse_accept(
-            'audio/*;q=0.2, audio/basic')
-
-    def test_that_both_items_are_returned(self):
-        self.assertEqual(len(self.parsed), 2)
+    
+    def test_that_all_items_are_returned(self):
+        parsed = headers.parse_accept('audio/*;q=0.2,audio/basic,'
+                                      'audio/aiff;q=0')
+        self.assertEqual(len(parsed), 3)
 
     def test_that_highest_priority_is_first(self):
-        self.assertEqual(
-            self.parsed[0], datastructures.ContentType('audio', 'basic'))
+        parsed = headers.parse_accept('audio/*;q=0.2,audio/basic,'
+                                      'audio/aiff;q=0')
+        self.assertEqual(parsed[0],
+                         datastructures.ContentType('audio', 'basic'))
 
     def test_that_quality_parameter_is_removed(self):
-        self.assertNotIn('q', self.parsed[1].parameters)
+        parsed = headers.parse_accept('audio/*;q=0.2,audio/basic,'
+                                      'audio/aiff;q=0')
+        for value in parsed:
+            self.assertNotIn('q', value.parameters)
 
 
-class WhenParsingHttpAcceptHeaderWithoutQualities(
-        test_case.TestCase, unittest.TestCase):
+class WhenParsingHttpAcceptHeaderWithoutQualities(unittest.TestCase):
 
     # Final example in http://tools.ietf.org/html/rfc7231#section-5.3.2
 
-    @classmethod
-    def act(cls):
-        cls.parsed = headers.parse_accept(
-            'text/*, text/plain, text/plain;format=flowed, */*')
-
     def test_that_most_specific_value_is_first(self):
+        parsed = headers.parse_accept('text/*, text/plain,'
+                                      'text/plain;format=flowed, */*')
         self.assertEqual(
-            self.parsed[0],
+            parsed[0],
             datastructures.ContentType('text', 'plain', {'format': 'flowed'}))
 
     def test_that_specific_value_without_parameters_is_second(self):
+        parsed = headers.parse_accept('text/*, text/plain,'
+                                      'text/plain;format=flowed, */*')
         self.assertEqual(
-            self.parsed[1], datastructures.ContentType('text', 'plain'))
+            parsed[1], datastructures.ContentType('text', 'plain'))
 
     def test_that_subtype_wildcard_is_next_to_last(self):
+        parsed = headers.parse_accept('text/*, text/plain,'
+                                      'text/plain;format=flowed, */*')
         self.assertEqual(
-            self.parsed[2], datastructures.ContentType('text', '*'))
+            parsed[2], datastructures.ContentType('text', '*'))
 
     def test_that_least_specific_wildcard_is_least_preferred(self):
-        self.assertEqual(self.parsed[3], datastructures.ContentType('*', '*'))
+        parsed = headers.parse_accept('text/*, text/plain,'
+                                      'text/plain;format=flowed, */*')
+        self.assertEqual(parsed[3], datastructures.ContentType('*', '*'))
 
 
 class WhenParsingAcceptCharsetHeader(unittest.TestCase):

--- a/tests/headers_parse_accept_tests.py
+++ b/tests/headers_parse_accept_tests.py
@@ -151,6 +151,27 @@ class WhenParsingAcceptLanguageHeader(unittest.TestCase):
             ['aa', '*', 'bb']
         )
 
+    def test_that_order_is_retained_without_quality(self):
+        self.assertEqual(
+            headers.parse_accept_language('de-Latn-DE,de-Latf-DE,'
+                                          'de-Latn-DE-1996'),
+            ['de-Latn-DE', 'de-Latf-DE', 'de-Latn-DE-1996'],
+        )
+
+    def test_that_explicit_highest_quality_is_first(self):
+        self.assertEqual(
+            headers.parse_accept_language('de-Latn-DE,de-Latf-DE,'
+                                          'de-Latn-DE-1996;q=1.0'),
+            ['de-Latn-DE-1996', 'de-Latn-DE', 'de-Latf-DE'],
+        )
+
+    def test_that_order_is_retained_for_explicit_highest_quality(self):
+        self.assertEqual(
+            headers.parse_accept_language('de-Latn-DE,de-Latf-DE;q=1.0,'
+                                          'de-Latn-DE-1996;q=1.0'),
+            ['de-Latf-DE', 'de-Latn-DE-1996', 'de-Latn-DE'],
+        )
+
 
 class WhenParsingAcceptHeaderWithExtensions(unittest.TestCase):
 


### PR DESCRIPTION
This PR corrects the parsing of preferences in accept-style headers so that it retains the original ordering.  [RFC4647](https://tools.ietf.org/html/rfc4647) and others recommend that the original sort order is retained particularly when quality values are not included.  This PR makes precisely that happen.

I also updated docs, trove classifiers, and the like _and_ remove the usage of the fluent testing package.  Fluent-Test has long outlived it's usefulness IMO.