### PR TITLE
Add algorithms.remove_url_auth

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,4 +4,3 @@ flake8>=2.2,<3
 pyflakes>=0.8,<1
 sphinx>=1.2,<2
 sphinxcontrib-httpdomain>=1.5,<2
-sphinx-rtd-theme>=0.1,<1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
   :func:`headers._parse_parameter_list` internal function.
 - Add support for parsing :rfc:`7239` ``Forwarded`` headers with
   :func:`headers.parse_forwarded`.
+- Add :func:`algorithms.remove_url_auth`
 
 `1.4.3`_ (30-Oct-2017)
 ----------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import sphinx_rtd_theme
-
 import ietfparse
 
 
@@ -23,10 +21,16 @@ source_suffix = '.rst'
 source_encoding = 'utf-8-sig'
 master_doc = 'index'
 pygments_style = 'sphinx'
-html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_static_path = []
 exclude_patterns = []
+html_sidebars = {
+    '**': ['about.html', 'navigation.html', 'searchbox.html'],
+}
+html_theme_options = {
+    'github_user': 'dave-shawley',
+    'github_repo': 'ietfparse',
+    'github_banner': True,
+}
 
 intersphinx_mapping = {
     'python': ('http://docs.python.org/3/', None),

--- a/tests/algorithm_tests.py
+++ b/tests/algorithm_tests.py
@@ -146,3 +146,31 @@ class PriorizationTests(unittest.TestCase):
         )
         self.assertEqual(str(selected),
                          'application/vnd.com.example+json; version=1')
+
+
+class RemoveUrlAuthTests(unittest.TestCase):
+
+    def test_that_auth_and_url_are_returned(self):
+        result = algorithms.remove_url_auth('http://me:secret@example.com')
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], ('me', 'secret'))
+        self.assertEqual(result[1], 'http://example.com')
+
+    def test_that_return_value_has_attributes_too(self):
+        result = algorithms.remove_url_auth('http://me:secret@example.com')
+        self.assertEqual(result.auth, ('me', 'secret'))
+        self.assertEqual(result.username, 'me')
+        self.assertEqual(result.password, 'secret')
+        self.assertEqual(result.url, 'http://example.com')
+
+    def test_that_username_can_be_omitted(self):
+        result = algorithms.remove_url_auth('http://:secret@example.com')
+        self.assertIsNone(result.username)
+        self.assertEqual(result.password, 'secret')
+        self.assertEqual(result.url, 'http://example.com')
+
+    def test_that_password_can_be_omitted(self):
+        result = algorithms.remove_url_auth('http://insecure@example.com')
+        self.assertEqual(result.username, 'insecure')
+        self.assertIsNone(result.password)
+        self.assertEqual(result.url, 'http://example.com')


### PR DESCRIPTION
I've come across the need to pull the auth portions out of a URL enough to warrant a function to do it.  This is particularly useful when you have an endpoint configured via an environment variable and want to use `requests` to hit the URL.
```python
other_ep = os.environ['OTHER_SERVICE_URL']   # http://me:secret@example.com:3143
auth, url = algorithms.remove_url(other_ep)  # (me, secret), 'http://example.com:3143'
rsp = requests.get(url, auth=auth)
```