### PR TITLE
Add content suffix support (RFC6839)

### DIFF
--- a/ietfparse/datastructures.py
+++ b/ietfparse/datastructures.py
@@ -33,34 +33,49 @@ class ContentType(object):
 
     """
 
-    def __init__(self, content_type, content_subtype, parameters=None):
+    def __init__(self, content_type, content_subtype, parameters=None,
+                 content_suffix=None):
         self.content_type = content_type.strip().lower()
         self.content_subtype = content_subtype.strip().lower()
+        if content_suffix is not None:
+            self.content_suffix = content_suffix.strip().lower()
+        else:
+            self.content_suffix = None
         self.parameters = {}
         if parameters is not None:
             for name in parameters:
                 self.parameters[name.lower()] = parameters[name]
 
     def __str__(self):
+        if self.content_suffix:
+            content_suffix = '+{0}'.format(self.content_suffix)
+        else:
+            content_suffix = ''
         if self.parameters:
-            return '{0}/{1}; {2}'.format(
-                self.content_type, self.content_subtype,
+            return '{0}/{1}{2}; {3}'.format(
+                self.content_type, self.content_subtype, content_suffix,
                 '; '.join('{0}={1}'.format(name, self.parameters[name])
                           for name in sorted(self.parameters))
             )
         else:
-            return '{0}/{1}'.format(self.content_type, self.content_subtype)
+            return '{0}/{1}{2}'.format(
+                self.content_type, self.content_subtype, content_suffix)
 
     def __repr__(self):  # pragma: no cover
-        return '<{0}.{1} {2}/{3}, {4} parameters>'.format(
+        if self.content_suffix:
+            content_suffix = '+{0}'.format(self.content_suffix)
+        else:
+            content_suffix = ''
+        return '<{0}.{1} {2}/{3}{4}, {5} parameters>'.format(
             self.__class__.__module__, self.__class__.__name__,
-            self.content_type, self.content_subtype,
+            self.content_type, self.content_subtype, content_suffix,
             len(self.parameters),
         )
 
     def __eq__(self, other):
         return (self.content_type == other.content_type and
                 self.content_subtype == other.content_subtype and
+                self.content_suffix == other.content_suffix and
                 self.parameters == other.parameters)
 
     def __lt__(self, other):

--- a/ietfparse/headers.py
+++ b/ietfparse/headers.py
@@ -211,11 +211,16 @@ def parse_content_type(content_type, normalize_parameter_values=True):
     """
     parts = _remove_comments(content_type).split(';')
     content_type, content_subtype = parts.pop(0).split('/')
+    if '+' in content_subtype:
+        content_subtype, content_suffix = content_subtype.split('+')
+    else:
+        content_suffix = None
     parameters = _parse_parameter_list(
         parts, normalize_parameter_values=normalize_parameter_values)
 
     return datastructures.ContentType(content_type, content_subtype,
-                                      dict(parameters))
+                                      dict(parameters),
+                                      content_suffix)
 
 
 def parse_forwarded(header_value, only_standard_parameters=False):

--- a/tests/datastructure_tests.py
+++ b/tests/datastructure_tests.py
@@ -8,13 +8,17 @@ class WhenCreatingContentType(unittest.TestCase):
     def setUp(self):
         super(WhenCreatingContentType, self).setUp()
         self.value = ContentType('ContentType', ' SubType ',
-                                 parameters={'Key': 'Value'})
+                                 parameters={'Key': 'Value'},
+                                 content_suffix='JSON')
 
     def should_normalize_primary_type(self):
         self.assertEqual(self.value.content_type, 'contenttype')
 
     def should_normalize_subtype(self):
         self.assertEqual(self.value.content_subtype, 'subtype')
+
+    def should_normalize_suffix(self):
+        self.assertEqual(self.value.content_suffix, 'json')
 
     def should_convert_parameters_to_lowercase(self):
         self.assertEqual(self.value.parameters['key'], 'Value')
@@ -59,13 +63,18 @@ class WhenComparingContentTypesForEquality(unittest.TestCase):
 
     def test_types_differing_by_case_are_equal(self):
         self.assertEqual(
-            ContentType('text', 'html', {'Level': '3.2'}),
-            ContentType('text', 'HTML', {'level': '3.2'}))
+            ContentType('text', 'html', {'Level': '3.2'}, 'JSON'),
+            ContentType('text', 'HTML', {'level': '3.2'}, 'json'))
 
     def test_types_with_differing_params_are_not_equal(self):
         self.assertNotEqual(
             ContentType('text', 'html', {'level': '1'}),
             ContentType('text', 'html', {'level': '2'}))
+
+    def test_types_with_differing_suffix_are_not_equal(self):
+        self.assertNotEqual(
+            ContentType('text', 'html', content_suffix='json'),
+            ContentType('text', 'html', content_suffix='xml'))
 
 
 class WhenComparingContentTypesForOrdering(unittest.TestCase):

--- a/tests/headers_content_type_tests.py
+++ b/tests/headers_content_type_tests.py
@@ -19,13 +19,16 @@ class SimpleContentTypeParsingTests(unittest.TestCase):
     def test_that_no_parameters_are_found(self):
         self.assertEqual(self.parsed.parameters, {})
 
+    def test_that_no_suffix_is_foudn(self):
+        self.assertEqual(self.parsed.content_suffix, None)
+
 
 class ParsingComplexContentTypeTests(unittest.TestCase):
 
     def setUp(self):
         super(ParsingComplexContentTypeTests, self).setUp()
         self.parsed = headers.parse_content_type(
-            'message/HTTP; version=2.0 (someday); MsgType="Request"',
+            'message/HTTP+JSON; version=2.0 (someday); MsgType="Request"',
             normalize_parameter_values=False)
 
     def test_that_type_is_parsed(self):
@@ -33,6 +36,9 @@ class ParsingComplexContentTypeTests(unittest.TestCase):
 
     def test_that_subtype_is_parsed(self):
         self.assertEqual(self.parsed.content_subtype, 'http')
+
+    def test_that_suffix_is_parsed(self):
+        self.assertEqual(self.parsed.content_suffix, 'json')
 
     def test_that_version_parameter_is_parsed(self):
         self.assertEqual(self.parsed.parameters['version'], '2.0')


### PR DESCRIPTION
This adds support for parsing the content suffix from a subtype. A number of them are defined in [RFC6839](https://tools.ietf.org/html/rfc6839).

For example, `application/vnd.test+json` will be parsed to the following:

**Type:** `application`
**Subtype:** `vnd.test`
**Suffix:** `json`