### PR TITLE
RFC-8288 groundwork

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include CONTRIBUTING.rst
+include ietfparse/py.typed
 include LICENSE
 include *requirements.txt
 include setupext.py
@@ -6,6 +7,7 @@ include tox.ini
 graft docs
 graft tests
 
+recursive-include ietfparse *.pyi
 global-exclude __pycache__
 global-exclude *.pyc
 global-exclude *.swp

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,8 @@ Changelog
 ---------------
 - Switched from travis-ci to circle-ci.
 - Add type stubs.
+- Allow "bad whitespace" around ``=`` in link header parameter lists as
+  indicated in :rfc:`8288#section-3`.
 
 `1.5.1`_ (04-Mar-2018)
 ----------------------

--- a/ietfparse/compat/parse.py
+++ b/ietfparse/compat/parse.py
@@ -9,38 +9,30 @@ import codecs
 
 __all__ = (
     'quote',
-    'splitnport',
-    'splitpasswd',
-    'splituser',
-    'unquote',
     'unquote_to_bytes',
     'urlencode',
-    'urlsplit',
-    'urlunsplit',
+    'urlparse',
+    'urlunparse',
 )
 
 try:
     from urllib.parse import (
         quote,
-        splitnport,
-        splitpasswd,
-        splituser,
-        unquote,
         unquote_to_bytes,
         urlencode,
-        urlsplit,
-        urlunsplit,
+        urlparse,
+        urlunparse,
     )
 except ImportError:  # pragma: no cover, coverage with tox
     from urllib import (
         quote,
-        splitnport,
-        splitpasswd,
-        splituser,
-        unquote,
+        unquote as _unquote,
         urlencode as _urlencode,
     )
-    from urlparse import urlsplit, urlunsplit
+    from urlparse import (
+        urlparse,
+        urlunparse,
+    )
 
     # unquote_to_bytes is extremely useful when you need to cleanly
     # unquote a percent-encoded UTF-8 sequence into a unicode string
@@ -51,7 +43,7 @@ except ImportError:  # pragma: no cover, coverage with tox
     # The return value of this function is the percent decoded raw
     # byte string - NOT A UNICODE STRING
     def unquote_to_bytes(s):
-        return unquote(s).encode('raw_unicode_escape')
+        return _unquote(s).encode('raw_unicode_escape')
 
     # urlencode did not encode its parameters in Python 2.x so we
     # need to implement that ourselves for compatibility.

--- a/ietfparse/compat/parse.pyi
+++ b/ietfparse/compat/parse.pyi
@@ -1,23 +1,19 @@
 from typing import Optional, Sequence, Tuple
 
 
+class _ParseResult:
+    fragment: Optional[str]
+    hostname: Optional[str]
+    password: Optional[str]
+    scheme: Optional[str]
+    username: Optional[str]
+    port: Optional[int]
+    path: Optional[str]
+    query: str
+    params: str
+
+
 def quote(a: bytes, safe: bytes) -> str:
-    ...
-
-
-def splitnport(host: str, defport: Optional[int] = -1) -> Tuple[str, int]:
-    ...
-
-
-def splitpasswd(a: str) -> Tuple[str, str]:
-    ...
-
-
-def splituser(a: str) -> Tuple[str, str]:
-    ...
-
-
-def unquote(a: str) -> str:
     ...
 
 
@@ -29,9 +25,9 @@ def urlencode(pairs: Sequence[Tuple[int, int]]) -> str:
     ...
 
 
-def urlsplit(url: str) -> Tuple[str, str, str, str, str]:
+def urlparse(url: str) -> _ParseResult:
     ...
 
 
-def urlunsplit(parts: Tuple[str, str, str, str, str]) -> str:
+def urlunparse(parsed: Tuple[str, str, str, str, str, str]) -> str:
     ...

--- a/ietfparse/headers.py
+++ b/ietfparse/headers.py
@@ -311,7 +311,8 @@ def parse_link(header_value, strict=True):
 
     for target, param_list in parse_links(sanitized):
         parser = _helpers.ParameterParser(strict=strict)
-        for name, value in _parse_parameter_list(param_list):
+        for name, value in _parse_parameter_list(
+                param_list, strip_interior_whitespace=True):
             parser.add_value(name, value)
 
         links.append(
@@ -337,7 +338,8 @@ def parse_list(value):
 def _parse_parameter_list(parameter_list,
                           normalized_parameter_values=_DEF_PARAM_VALUE,
                           normalize_parameter_names=False,
-                          normalize_parameter_values=True):
+                          normalize_parameter_values=True,
+                          strip_interior_whitespace=False):
     """
     Parse a named parameter list in the "common" format.
 
@@ -348,6 +350,8 @@ def _parse_parameter_list(parameter_list,
         as *truthy*, then parameter values are case-folded to lower case
     :keyword bool normalized_parameter_values: alternate way to spell
         ``normalize_parameter_values`` -- this one is deprecated
+    :keyword bool strip_interior_whitespace: remove whitespace between
+        name and values surrounding the ``=``
     :return: a sequence containing the name to value pairs
 
     The parsed values are normalized according to the keyword parameters
@@ -367,6 +371,8 @@ def _parse_parameter_list(parameter_list,
         param = param.strip()
         if param:
             name, value = param.split('=')
+            if strip_interior_whitespace:
+                name, value = name.strip(), value.strip()
             if normalize_parameter_names:
                 name = name.lower()
             if normalize_parameter_values:

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,12 @@ universal = 1
 [build_sphinx]
 all-files = 1
 
+[coverage:report]
+show_missing = 1
+
+[coverage:run]
+branch = 1
+
 [nosetests]
 nocapture = 1
 verbosity = 2

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setuptools.setup(
     description='Parse formats defined in IETF RFCs.',
     long_description=long_description,
     packages=setuptools.find_packages(exclude=['tests', 'tests.*']),
+    include_package_data=True,
     zip_safe=True,
     platforms='any',
     install_requires=install_requirements,

--- a/tests/headers_cache_control_tests.py
+++ b/tests/headers_cache_control_tests.py
@@ -3,34 +3,27 @@ import unittest
 from ietfparse import headers
 
 
-class WhenParsingCacheControl(unittest.TestCase):
-    def setUp(self):
-        super(WhenParsingCacheControl, self).setUp()
-        self.parsed = headers.parse_cache_control(
-            'public, must-revalidate, max-age=100, min-fresh=20, '
-            'community="UCI", x-token=" foo bar ", x-should-be-ignored=')
+class CacheControlParsingTests(unittest.TestCase):
+    def test_that_flags_are_parsed_as_booleans(self):
+        flags = {
+            'must-revalidate', 'no-cache', 'no-store', 'no-transform',
+            'only-if-cached', 'public', 'private', 'proxy-revalidate'
+        }
+        for flag in flags:
+            parsed = headers.parse_cache_control(flag)
+            self.assertIs(parsed[flag], True)
 
-    def test_that_public_is_parsed(self):
-        print(self.parsed)
-        self.assertTrue(self.parsed.get('public'))
+    def test_that_numeric_parameters_are_parsed(self):
+        parsed = headers.parse_cache_control('min-fresh=20, max-age=100')
+        self.assertEqual(100, parsed['max-age'])
+        self.assertEqual(20, parsed['min-fresh'])
 
-    def test_that_must_revalidate_is_parsed(self):
-        self.assertTrue(self.parsed.get('must-revalidate'))
+    def test_that_string_parameters_are_parsed(self):
+        parsed = headers.parse_cache_control(
+            'community="UCI", x-token=" foo bar "')
+        self.assertEqual('UCI', parsed['community'])
+        self.assertEqual(' foo bar ', parsed['x-token'])
 
-    def test_that_private_is_not_set(self):
-        self.assertNotIn('private', self.parsed)
-
-    def test_that_max_age_is_set(self):
-        self.assertEqual(self.parsed.get('max-age'), 100)
-
-    def test_that_min_fresh_is_set(self):
-        self.assertEqual(self.parsed.get('min-fresh'), 20)
-
-    def test_that_community_is_set(self):
-        self.assertEqual(self.parsed.get('community'), 'UCI')
-
-    def test_that_extension_parameter_is_parsed(self):
-        self.assertEqual(self.parsed.get('x-token'), ' foo bar ')
-
-    def test_that_empty_parameter_value_is_ignored(self):
-        self.assertIsNone(self.parsed.get('x-should-be-ignored'))
+    def test_that_empty_parameter_values_are_ignored(self):
+        parsed = headers.parse_cache_control('x-should-be-ignored=')
+        self.assertNotIn('x-should-be-ignored', parsed)

--- a/tests/headers_link_tests.py
+++ b/tests/headers_link_tests.py
@@ -46,6 +46,22 @@ class LinkHeaderParsingTests(unittest.TestCase):
         self.assertEqual(parsed[0].parameters, [('title*', 'title*'),
                                                 ('title', 'title*')])
 
+    def test_optional_white_space(self):
+        parsed = headers.parse_link('<one> ; rel="one" , <two> ; rel=two')
+        self.assertEqual(2, len(parsed))
+        self.assertEqual('one', dict(parsed[0].parameters)['rel'])
+        self.assertEqual('two', dict(parsed[1].parameters)['rel'])
+
+    def test_bad_white_space(self):
+        parsed = headers.parse_link('<one>; rel = "one", <two>; rel = two')
+        self.assertEqual(2, len(parsed))
+
+        self.assertEqual('one', dict(parsed[0].parameters)['rel'])
+        self.assertEqual('<one>; rel="one"', str(parsed[0]))
+
+        self.assertEqual('two', dict(parsed[1].parameters)['rel'])
+        self.assertEqual('<two>; rel="two"', str(parsed[1]))
+
 
 class MalformedLinkHeaderTests(unittest.TestCase):
     def test_that_value_error_when_url_brackets_are_missing(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,lint
+envlist = py27,py35,py36,py37,py38,lint,coverage
 toxworkdir = {toxinidir}/build/tox
 
 [testenv]
@@ -20,3 +20,7 @@ commands =
 	flake8 --output-file=build/pep8.txt
 	mypy --strict --package ietfparse
 	yapf -dr ietfparse tests
+
+[testenv:coverage]
+commands =
+	{envbindir}/nosetests --with-coverage --cover-min-percentage=100


### PR DESCRIPTION
Somehow I missed that there is a new version of the Web Linking RFC available (since 2017 😞).  This PR lays the groundwork for [RFC-8288](https://tools.ietf.org/html/rfc8288) without any breaking changes.  Yes ... this implies that there are breaking changes coming since "rel" is now required by [RFC-8288§3.3](https://tools.ietf.org/html/rfc8288#section-3.3).