### PR TITLE
Soft removal of support for Pythons before 3.7.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,26 +16,6 @@ jobs:
           paths:
             - cc-test-reporter
 
-  python-2-test:
-    working_directory: ~/ietfparse
-    docker:
-      - image: circleci/python:2
-    steps:
-      - checkout
-      - attach_workspace:
-          at: ~/ietfparse/tmp
-      - run: |
-          mkdir build
-          sudo pip install '.[test]' coveralls
-          coverage run -m unittest discover
-          coverage xml
-          ./tmp/cc-test-reporter format-coverage -t coverage.py -o tmp/python2-coverage.json
-          coveralls
-      - persist_to_workspace:
-          root: tmp
-          paths:
-            - python2-coverage.json
-
   python-3-test:
     working_directory: ~/ietfparse
     docker:
@@ -64,7 +44,7 @@ jobs:
       - attach_workspace:
           at: ~/ietfparse/tmp
       - run: |
-          ./tmp/cc-test-reporter sum-coverage tmp/*-coverage.json -p 2 -o tmp/codeclimate-total.json
+          ./tmp/cc-test-reporter sum-coverage tmp/*-coverage.json -p 1 -o tmp/codeclimate-total.json
           ./tmp/cc-test-reporter upload-coverage -i tmp/codeclimate-total.json
 
   distribute-tag:
@@ -86,15 +66,11 @@ workflows:
   build-workflow:
     jobs:
       - build
-      - python-2-test:
-          requires:
-            - build
       - python-3-test:
           requires:
             - build
       - upload-coverage:
           requires:
-            - python-2-test
             - python-3-test
       - distribute-tag:
           context: org-global

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2020, Dave Shawley
+Copyright (c) 2014-2021, Dave Shawley
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,10 @@ Changelog
 
 .. py:currentmodule:: ietfparse
 
+`Next release`_
+---------------
+- Removing support for Python versions before 3.7
+
 `1.7.0`_ (04-Nov-2020)
 ----------------------
 .. rubric:: Behavioural Change

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,10 +18,7 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -38,17 +35,15 @@ packages = find:
 
 [options.extras_require]
 dev =
-    coverage==5.3
-    flake8==3.8.4
-    mock>1.0,<2; python_version<"3"
-    mypy==0.790
-    sphinx==3.3.0
+    coverage==5.5
+    flake8==3.9.2
+    mypy==0.910
+    sphinx==4.1.1
     sphinxcontrib-httpdomain==1.7.0
-    tox==3.20.1
-    yapf==0.29.0
+    tox==3.24.1
+    yapf==0.31.0
 test =
-    coverage==5.3
-    mock>1.0,<2; python_version<"3"
+    coverage==5.5
 
 [options.packages.find]
 exclude =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,py38,py39,lint,coverage
+envlist = py37,py38,py39,lint,coverage
 toxworkdir = {toxinidir}/build/tox
 
 [testenv]
@@ -9,10 +9,9 @@ extras = test
 
 [testenv:lint]
 deps =
-	flake8==3.8.4
-	mypy==0.720; python_version<"3"
-	mypy==0.790; python_version>"3"
-	yapf==0.29.0
+	flake8==3.9.2
+	mypy==0.910
+	yapf==0.31.0
 commands =
 	flake8 --output-file=build/pep8.txt
 	mypy --strict --package ietfparse


### PR DESCRIPTION
I decided to remove support for Python versions before 3.7.  This change does not change any code.  I simply removed the metadata and testing around older Python versions.  I plan on releasing a new MAJOR version that updates the code to use type annotations and removes compatibility code.  First I'm going to release a minor bump with the metadata changes.