### PR TITLE
Deprecate URL related functions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,10 @@ Changelog
 - Changed ``algorithms.RemoveUrlAuthResult`` from a named tuple to a proper class.
 - Deprecated using ``len()`` on the return value from :func:`algorithms.remove_url_auth`
 - Replace type hints with annotations.
+- Deprecated ``rewrite_url`` and ``remove_url_auth``.  Use `yarl`_ instead.  It is an
+  awesome library and a more general solution.
+
+.. _yarl: https://pypi.org/project/yarl/
 
 `1.8.0`_ (11-Aug-2021)
 ----------------------

--- a/docs/rfcs.rst
+++ b/docs/rfcs.rst
@@ -7,18 +7,6 @@ Relevant RFCs
   the :mailheader:`Content-Type` header described in :rfc:`2045` and
   fully specified in section `5.1`_.
 
-`RFC-3986`_
------------
-- :func:`ietfparse.algorithms.rewrite_url` implements encoding and
-  parsing per :rfc:`3986`.
-
-`RFC-5980`_
------------
-- :func:`ietfparse.algorithms.rewrite_url` encodes host names according
-  to :rfc:`5980` for the schemes identified by
-  :data:`~ietfparse.algorithms.IDNA_SCHEMES`.  Encoding can also be
-  forced using the ``encode_with_idna`` keyword parameter.
-
 `RFC-5988`_
 -----------
 - :func:`ietfparse.headers.parse_link_header` parses a :mailheader:`Link`
@@ -54,10 +42,6 @@ Relevant RFCs
 
 .. _RFC-2045: https://tools.ietf.org/html/rfc2045
 .. _5.1: https://tools.ietf.org/html/rfc2045#section-5.1
-
-.. _RFC-3986: https://tools.ietf.org/html/rfc3986
-
-.. _RFC-5980: https://tools.ietf.org/html/rfc5980
 
 .. _RFC-5988: https://tools.ietf.org/html/rfc5988
 

--- a/docs/urls.rst
+++ b/docs/urls.rst
@@ -2,6 +2,12 @@
 
 URL Processing
 ==============
+
+.. warning::
+
+   The URL related functions will be removed in version 2.0.
+   Use `yarl <https://yarl.readthedocs.io/>` instead.
+
 If your applications have reached the `Glory of REST`_ by using hypermedia
 controls throughout, then you aren't manipulating URLs a lot unless you
 are responsible for generating them.  However, if you are interacting with

--- a/ietfparse/algorithms.py
+++ b/ietfparse/algorithms.py
@@ -1,19 +1,16 @@
 """
 Implementations of algorithms from various specifications.
 
-- :func:`.remove_url_auth`: removes and returns the auth portion
-  of a URL.  This is particularly handy for processing URLs from
-  configuration files or environment variables.
-- :func:`.rewrite_url`: modify a portion of a URL.
 - :func:`.select_content_type`: select the best match between a
   HTTP ``Accept`` header and a list of available ``Content-Type`` s
 
 This module implements some of the more interesting algorithms
 described in IETF RFCs.
 
-.. data:: IDNA_SCHEMES
+.. warning::
 
-   A collection of schemes that use IDN encoding for its host.
+   The URL related functions will be removed in version 2.0.
+   Use `yarl <https://yarl.readthedocs.io/>`_ instead.
 
 """
 from __future__ import annotations
@@ -266,7 +263,16 @@ def rewrite_url(input_url: str,
     URLs since *no URL escaping is performed*.  This is the obvious
     pass through case that is almost always present.
 
+    .. deprecated:: 1.9
+       URL processing functions are scheduled for removal in 2.0.
+       Please use `yarl`_ instead.  It is simply a better solution.
+
+    .. _yarl: https://yarl.readthedocs.io/
+
     """
+    warnings.warn(
+        'rewrite_url will be removed in 2.0, please use yarl instead',
+        DeprecationWarning)
     result = parse.urlparse(input_url)
 
     if scheme is unspecified_str:
@@ -386,7 +392,16 @@ def remove_url_auth(url: str) -> RemoveUrlAuthResult:
     >>> result.url
     'http://example.com'
 
+    .. deprecated:: 1.9
+       URL processing functions are scheduled for removal in 2.0.
+       Please use `yarl`_ instead.  It is simply a better solution.
+
+    .. _yarl: https://yarl.readthedocs.io/
+
     """
+    warnings.warn(
+        'remove_url_auth will be removed in 2.0, please use yarl instead',
+        DeprecationWarning)
     parts = parse.urlparse(url)
     return RemoveUrlAuthResult(auth=(parts.username or None, parts.password),
                                url=rewrite_url(url, user=None, password=None))


### PR DESCRIPTION
Use [yarl](https://yarl.readthedocs.io/) instead.  It does a better job at manipulating URLs in every way.  The only thing that you might want to do is define a helper for sanitizing URLs if you find `url.with_password('***')` doesn't work for you.  This will remove a lot of complexity from this library along with the burden of maintaining it.