### PR TITLE
Make root readme differ from the docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,25 @@
----
-title: Home
-hide:
-  - navigation
-  - toc
----
-# ietfparse
+[![PyPI - Version](https://img.shields.io/pypi/v/ietfparse)](https://pypi.org/project/ietfparse/)
+[![Documentation Status](https://readthedocs.org/projects/ietfparse/badge/?version=latest)](https://ietfparse.readthedocs.io/en/latest/?badge=latest)
+[![Circle-CI](https://circleci.com/gh/dave-shawley/ietfparse.svg?style=shield)](https://circleci.com/gh/dave-shawley/ietfparse)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dave-shawley_ietfparse&metric=coverage)](https://sonarcloud.io/summary/overall?id=dave-shawley_ietfparse)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=dave-shawley_ietfparse&metric=alert_status)](https://sonarcloud.io/summary/overall?id=dave-shawley_ietfparse)
 
-This is a gut reaction to the wealth of ways to parse URLs, MIME headers,
-HTTP messages and other things described by IETF RFCs.  They range from
-the Python standard library (`urllib`) to be buried in the guts of other
+This project is a gut reaction to the wealth of ways to parse URLs, MIME
+headers, HTTP messages and other things described by IETF RFCs. They range
+from the Python standard library (`urllib`) to be buried in the guts of other
 *kitchen sink* libraries (`werkzeug`) and most of them are broken in one
 way or the other.
 
-So why create another one?  Good question... glad that you asked.  This is
+So why create another one?  *Good question...* glad that you asked. This is
 a companion library to the great packages out there that are responsible for
-communicating with other systems.  I'm going to concentrate on providing a
-crisp and usable set of APIs that concentrate on parsing text.  Nothing more.
+communicating with other systems. I'm going to concentrate on providing a
+crisp and usable set of APIs that concentrate on parsing text. Nothing more.
 Hopefully by concentrating on the specific task of parsing things, the result
 will be a beautiful and usable interface to the text strings that power the
 Internet world.
 
-Here's a sample of the code that this library lets you write::
+Here's a sample of the code that this library lets you write:
+
 ```python
 from ietfparse import algorithms, headers
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-docs/index.md
+---
+title: Home
+hide:
+  - navigation
+  - toc
+---
+# ietfparse
+
+This is a gut reaction to the wealth of ways to parse URLs, MIME headers,
+HTTP messages and other things described by IETF RFCs.  They range from
+the Python standard library (`urllib`) to be buried in the guts of other
+*kitchen sink* libraries (`werkzeug`) and most of them are broken in one
+way or the other.
+
+So why create another one?  Good question... glad that you asked.  This is
+a companion library to the great packages out there that are responsible for
+communicating with other systems.  I'm going to concentrate on providing a
+crisp and usable set of APIs that concentrate on parsing text.  Nothing more.
+Hopefully by concentrating on the specific task of parsing things, the result
+will be a beautiful and usable interface to the text strings that power the
+Internet world.
+
+Here's a sample of the code that this library lets you write::
+```python
+from ietfparse import algorithms, headers
+
+def negotiate_versioned_representation(request, handler, data_dict):
+    requested = headers.parse_accept(request.headers['accept'])
+    selected, _ = algorithms.select_content_type(requested, [
+        headers.parse_content_type('application/example+json; v=1'),
+        headers.parse_content_type('application/example+json; v=2'),
+        headers.parse_content_type('application/json'),
+    ])
+
+    output_version = selected.parameters.get('v', '2')
+    if output_version == '1':
+        handler.set_header('Content-Type', 'application/example+json; v=1')
+        handler.write(generate_legacy_json(data_dict))
+    else:
+        handler.set_header('Content-Type', 'application/example+json; v=2')
+        handler.write(generate_modern_json(data_dict))
+```


### PR DESCRIPTION
This started out as me trying to figure out how to get GitHub's readme renderer to ignore the YaML metadata that hides the sidebar on _docs/index.md_. After deciding that there really isn't a good way to get the renderer to ignore metadata _and_ have mkdocs still process it, I ended up unlinking them. The GitHub README includes the badges again and the docs do not. Seems like a decent separation for the time being.