### PR TITLE
Rework LinkHeader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - checkout
       - run: |
-          pip install --user 'hatch==1.13.0' 'hatchling<1.26'
+          pip install --user hatch
           hatch run lint
 
   code-climate:
@@ -42,10 +42,9 @@ jobs:
           at: code-climate
       - run: |
           ./code-climate/test-reporter before-build
-          pip install --user 'hatch==1.13.0' 'hatchling<1.26'
-          hatch env run -i python=<< parameters.python-version >> -e all ci
+          pip install --user hatch
+          hatch env run -i python=<< parameters.python-version >> -e ci test
           code-climate/test-reporter format-coverage -t coverage.py -o coverage/codeclimate.<< parameters.python-version >>.json
-          mv .coverage coverage/data-<< parameters.python-version >>
       - persist_to_workspace:
           root: coverage
           paths:
@@ -63,11 +62,9 @@ jobs:
       - attach_workspace:
           at: coverage
       - run: |
-          pip install --user coverage
+          pip install --user hatch
           ./code-climate/test-reporter sum-coverage coverage/codeclimate.*.json
-          coverage combine --data-file coverage/data coverage/data-*
-          coverage report --data-file coverage/data
-          coverage xml --data-file coverage/data -o coverage/coverage.xml
+          hatch run build-report
       - persist_to_workspace:
           root: coverage
           paths:
@@ -102,8 +99,8 @@ jobs:
     steps:
       - checkout
       - run: |
-          pip install --user --upgrade build readme_renderer twine wheel
-          python -m build --sdist --wheel
+          pip install --user hatch twine
+          hatch build
           twine check dist/*
           twine upload --skip-existing dist/*
           curl -XPOST -d "token=$READTHEDOCS_TOKEN" https://readthedocs.org/api/v2/webhook/ietfparse/28564/

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /env*/
 /htmlcov/
 /site/
+/test-results/
 __pycache__/
 
 coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![PyPI - Version](https://img.shields.io/pypi/v/ietfparse)](https://pypi.org/project/ietfparse/)
 [![Documentation Status](https://readthedocs.org/projects/ietfparse/badge/?version=latest)](https://ietfparse.readthedocs.io/en/latest/?badge=latest)
 [![Circle-CI](https://circleci.com/gh/dave-shawley/ietfparse.svg?style=shield)](https://circleci.com/gh/dave-shawley/ietfparse)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dave-shawley_ietfparse&metric=coverage)](https://sonarcloud.io/summary/overall?id=dave-shawley_ietfparse)
+![Code Climate coverage](https://img.shields.io/codeclimate/coverage/dave-shawley/ietfparse)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=dave-shawley_ietfparse&metric=alert_status)](https://sonarcloud.io/summary/overall?id=dave-shawley_ietfparse)
 
 This project is a gut reaction to the wealth of ways to parse URLs, MIME

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@
 - `headers.parse_link` changed to honor the allow multiple `media` and `type`
   parameters as described in [RFC-8288-section-3.4.1]. The first value is
   retained.
+- `datastructures.LinkHeader` changed to combine multiple relationship type
+  (rel) parameters into a single space-separated parameter as described in
+  [RFC-8288-section-3]. Note that this is only relevant if you disable strict
+  mode parsing.
 - replaced setuptools with [hatch](https://hatch.pypa.io/)
 - converted positional Boolean parameters to keyword-only parameters
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 - [pre-commit](https://pre-commit.com/) utility usage
 - `datastructures.LinkHeader.rel` property
+- indexed parameter lookup in `datastructures.LinkHeader`
 
 ### Changed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,11 +2,16 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- `datastructures.LinkHeader` is now immutable
+
 ### Added
 
 - [pre-commit](https://pre-commit.com/) utility usage
 - `datastructures.LinkHeader.rel` property
 - indexed parameter lookup in `datastructures.LinkHeader`
+- `datastructures.ImmutableSequence` helper class
 
 ### Changed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 ### Added
 
 - [pre-commit](https://pre-commit.com/) utility usage
+- `datastructures.LinkHeader.rel` property
 
 ### Changed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,9 @@
 
 ### Changed
 
+- `headers.parse_link` changed to honor the allow multiple `media` and `type`
+  parameters as described in [RFC-8288-section-3.4.1]. The first value is
+  retained.
 - replaced setuptools with [hatch](https://hatch.pypa.io/)
 - converted positional Boolean parameters to keyword-only parameters
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -13,122 +13,85 @@ you do not want to.  But if you do, they will be more than welcome.
 
 ## Set up a development environment
 
-The first thing that you need to do is set up a development environment
-so that you can run the test suite.  The easiest way to do that is to
-create a virtual environment for your endeavours:
+This project uses the [hatch] project manager, so you should install it
+to make your life easier. I usually install it as a "user install".
+Make sure that you have the target directory in your path.
 
-```
-$ python -mvenv env
-```
-
-!!! note
-    If you want to continue using `pip`, then you will need a fairly modern
-    version of pip (at least pip version 21.3) for [PEP-660] support.  You
-    can also use `hatch` by running `hatch env create` instead.  I recommend
-    using `pip` since it is a more comfortable workflow for most developers.
-
-[hatch]: https://hatch.pypa.io/
-
-The next step is to install the development tools that you will need.  These
-are included in the *extra* `.[dev]`:
-
-```
-$ env/bin/pip install -qe '.[dev]'
+```commandline
+$ python3 -m pip install --user hatch
+$ echo "Installed hatch into $(python3 -m site --user-base)/bin"
 ```
 
-THe last step is to install the git pre-commit hooks so you don't have to
-remember to run the style checks... _nothing is more annoying than pushing
-a PR only to have it fail for formatting differences._
+Once you have hatch installed, you are ready to starting writing code.
 
+```commandline
+$ hatch shell
+(ietfparse) $
 ```
-$ env/bin/pre-commit install --install-hooks
+
+### Manual virtual environments
+
+You are not required to use hatch. I find that it makes life a bit easier,
+but it is easy enough to create and manage your own virtual environments.
+
+```commandline
+$ python3 -m venv env
+$ . ./env/bin/activate
+(ietfparse) $ pip install '.[dev]'
+(ietfparse) $ pip install -e .
+```
+
+## pre-commit hooks
+
+Before you start modifying things, install the pre-commit hooks so you
+don't have to remember to run the style checks manually... _nothing is
+more annoying than pushing a PR only to have it fail for something being
+incorrectly formatted._
+
+```commandline
+(ietfparse) $ pre-commit install --install-hooks
 ```
 
 ## Running tests
 
-The easiest way to run the test suite is with *python -m unittest*.
-It will run the test suite with the currently installed python version
-and report the result of the test run:
+I use [pytest] as my test runner of choice. However, I do not use it as
+a testing framework so please continue to use the assertions exposed by
+the [unittest.UnitTest] class instead of raw `assert` statements.
+Running the test suite is as easy as `hatch run test`. The nice thing
+about hatch is that you do not need to manually activate the environment.
 
-```
-$ env/bin/python -munittest
-......................................................................
-......................................................................
-.........................
-   ----------------------------------------------------------------------
-Ran 165 tests in 0.016s
-
-OK
-```
-
-If you want to see the test coverage, then use the excellent [coverage] utility:
-
-```
-$ env/bin/coverage run -munittest
-......................................................................
-......................................................................
-.........................
-   ----------------------------------------------------------------------
-Ran 165 tests in 0.023s
-
-OK
-$ env/bin/coverage report
-Name                                  Stmts   Miss Branch BrPart  Cover   Missing
-   ---------------------------------------------------------------------------------
-ietfparse/__init__.py                     2      0      2      0   100%
-ietfparse/_helpers.py                    30      0     16      0   100%
-ietfparse/algorithms.py                 147      0     80      0   100%
-ietfparse/compat/__init__.py              0      0      0      0   100%
-ietfparse/compat/parse.py                 4      0      0      0   100%
-ietfparse/datastructures.py              47      0     32      0   100%
-ietfparse/errors.py                      11      0      0      0   100%
-ietfparse/headers.py                    155      0     76      0   100%
-tests/__init__.py                         0      0      0      0   100%
-tests/test_algorithm.py                  76      0      8      0   100%
-tests/test_datastructure.py              43      0      0      0   100%
-tests/test_headers_cache_control.py      19      0      2      0   100%
-tests/test_headers_content_type.py       39      0      0      0   100%
-tests/test_headers_deprecation.py        22      0      0      0   100%
-tests/test_headers_forwarded.py          28      0      0      0   100%
-tests/test_headers_link.py               80      0      0      0   100%
-tests/test_headers_list.py               11      0      0      0   100%
-tests/test_headers_parse_accept.py       68      0      2      0   100%
-tests/test_url.py                       125      0      0      0   100%
-   ---------------------------------------------------------------------------------
-TOTAL                                   907      0    218      0   100%
+```commandline
+$ hatch run test
+cmd [1] | pre-commit run --all-files
+... lint & formatting checks omitted
+cmd [2] | mypy -p ietfparse -p tests
+Success: no issues found in 15 source files
+cmd [3] | python -m coverage run -m pytest tests
+========================== test session starts ==========================
+platform darwin -- Python 3.12.7, pytest-7.1.2, pluggy-1.5.0
+... pytest output omitted
+=================== 120 passed, 120 warnings in 0.10s ===================
+cmd [4] | python -m coverage report
+Name                          Stmts   Miss Branch BrPart  Cover   Missing
+-------------------------------------------------------------------------
+ietfparse/__init__.py             4      0      0      0   100%
+ietfparse/_helpers.py            30      0     14      0   100%
+ietfparse/algorithms.py          42      0     22      0   100%
+ietfparse/datastructures.py     100      0     26      0   100%
+ietfparse/errors.py               8      0      0      0   100%
+ietfparse/headers.py            162      0     74      0   100%
+-------------------------------------------------------------------------
+TOTAL                           346      0    136      0   100%
 ```
 
-Time to address the elephant in the room ... I decided to stop using the
-venerable *nosetests* since it is unmaintained. I used to suggest using
-*setup.py* as the developer's swiss army knife. I have recently changed my
-opinion on that as well. *Just use the tools directly.*
-
-The more interesting pivot is that I *did not choose to use pytest* or any
-other replacement for nose.  The [unittest][] module together with the
-[coverage] utility is more than capable of handling the task at hand without
-depending on yet another utility. In full transparency, I do use pytest in
-my development environment.
-
-Before you can call the code complete, you should make sure that it works
-across the supported python versions. My CI pipeline will take care of
-making sure that this is the case when you create a pull request.  If you
-want to do this before submitting, then you will have to install [hatch].
-The easiest way to do this is to install it using `pip install --user`.
-Hatch will store virtual environments somewhere in your home directory
-(see [Hatch Configuration](https://hatch.pypa.io/latest/config/hatch/)
-and [User Installs] for additional information).
-
-```
-$ python3.9 -m pip install --user hatch
-$ python3.9 -m hatch run all:test
-```
-
-If the tests all pass, then it is time to submit a PR.
+The "lint" script will run the pre-commit hooks that invoke [ruff] for style
+and format checks, followed by [mypy] for static type checks. It is a useful
+target when you are refactoring since it is a little faster.
 
 ## Submitting a Pull Request
 
 The first thing to do is to fork the repository and set up a nice shiny
-environment in it.  Once you can run the tests, it's time to write some.
+environment for it.  Once you can run the tests, it's time to write some.
 I developed this library using a test-first methodology.  If you are
 fixing a defect, then write a test that verifies the correct (desired)
 behavior.  It should fail.  Now, fix the defect making the test pass in
@@ -138,7 +101,7 @@ functionality to make the test pass.  Then, on to the next test.  This is
 *test driven development* at its core.  This actually is pretty important
 since **pull requests that are not tested will not be merged**.
 
-The easiest way to check coverage is to use `tox -e coverage` which runs
+The easiest way to check coverage is to run `hatch run test` which runs
 the tests with coverage enabled and reports the coverage.  It will fail if
 you have less than 100% coverage.
 
@@ -150,62 +113,29 @@ commit is, the easier it will be to squash and rearrange them.
 
 When your change is written and tested, make sure to update and/or add
 documentation as needed.  The documentation suite is written using
-ReStructuredText and the excellent [sphinx] utility.  If you don't think
-that documentation matters, read Kenneth Reitz's [Documentation is King]
-presentation.  Pull requests that are not simply bug fixes will almost
-always require some documentation.
+Markdown and the [mkdocs] utility.  If you don't think that documentation
+matters, read Kenneth Reitz's [Documentation is King] presentation.  Pull
+requests that are not simply bug fixes will almost always require some
+documentation... _updates to the changelog at the very least_.
+
+[mkdocs] makes it easy to write documentation by running a small
+development web server, rebuilding documentation when fiels change, and
+using a nifty web-socket to refresh the web browser as well.
+
+```commandline
+$ hatch run serve-docs
+...
+INFO    -  [08:01:22] Serving on http://127.0.0.1:8000/
+```
 
 After the tests are written, code is complete, and documents are up to
 date, it is time to push your code back to github.com and submit a pull
 request against the upstream repository.
 
-## Using hatch
-
-I replaced setuptools & [tox] with [hatch] to manage project metadata,
-dependencies, and provide developer-friendly scripts.  Best of all is that it
-does not require that you use it unless you want to!  I did have to change
-this guide since I replaced tox with hatch environments.  So I lied a little
-bit... if you want to test across multiple python versions, then you will need
-to install hatch (or let the CI pipeline take care of it).  I installed the
-hatch utility using the "--user" option since that makes it available
-regardless of which environment is activated::
-
-```
-$ python3.9 -m pip install --user hatch
-```
-
-If you want to run the `hatch` utility as a CLI utility instead of a module,
-then you need to add the "user installation" directory to your path. You can
-find the user installation root using::
-
-```
-$ python3.9 -m site --user-base
-/Users/daveshawley/.local
-```
-
-Simply add the *bin* directory to your path and you can run `hatch`
-instead of `python3.9 -m hatch`.  If you are unfamiliar with "user
-installs", then read [User Installs] for the detailed version.
-
-Once you have hatch installed and available, running any of the `hatch`
-commands will result in the creation of a new virtual environment or updating
-the existing one.  For example::
-
-```
-$ hatch run test
-```
-
-will ensure that the virtual environment exists and run the "test" script
-which is `python -m unittest discover -f tests`.  You can see the available
-scripts with `hatch env show`.  The `all` environment can be used to run
-the commands across all supported Python versions (e.g., `hatch run all:test`).
-
-[coverage]: https://coverage.readthedocs.io/
-[flake8]: https://flake8.readthedocs.io/
 [hatch]: https://hatch.pypa.io/
-[sphinx]: https://www.sphinx-doc.org/
-[tox]: https://tox.readthedocs.io/
-[virtualenv]: https://virtualenv.pypa.io/en/stable/
+[mkdocs]: https://www.mkdocs.org/
+[mypy]: https://mypy.readthedocs.io/en/stable/
+[ruff]: https://docs.astral.sh/ruff/
+[unittest.TestCase]: https://docs.python.org/3/library/unittest.html#unittest.TestCase
 
 [Documentation is King]: https://www.kennethreitz.org/documentation-is-king/
-[User Installs]: https://pip.pypa.io/en/stable/user_guide/#user-installs

--- a/docs/header-parsing.md
+++ b/docs/header-parsing.md
@@ -13,6 +13,17 @@ Instead of inventing another list of *garbage-in -> garbage-out* exception
 types, I chose to simply let the underlying exception propagate.  This means
 that you should always guard against at least this set of exceptions.
 
+| Header                              | Represented as...                                    | Parsed by...                                |
+|-------------------------------------|------------------------------------------------------|---------------------------------------------|
+| [Accept](#accept)                   | sequence of [ietfparse.datastructures.ContentType][] | [ietfparse.headers.parse_accept][]          |
+| [Accept-Charset](#accept-charset)   | sequence of strings                                  | [ietfparse.headers.parse_accept_charset][]  |
+| [Accept-Encoding](#accept-encoding) | sequence of strings                                  | [ietfparse.headers.parse_accept_encoding][] |
+| [Accept-Language](#accept-language) | sequence of strings                                  | [ietfparse.headers.parse_accept_language][] |
+| [Cache-Control](#cache-control)     | mapping of parameter to value                        | [ietfparse.headers.parse_cache_control][]   |
+| [Content-Type](#content-type)       | [ietfparse.datastructures.ContentType][]             | [ietfparse.headers.parse_content_type][]    |
+| [Forwarded](#forwarded)             | sequence of mappings                                 | [ietfparse.headers.parse_forwarded][]       |
+| [Link](#link)                       | sequence of [ietfparse.datastructures.LinkHeader][]  | [ietfparse.headers.parse_link][]            |
+
 ## Accept
 
 [ietfparse.headers.parse_accept][] parses the [HTTP-Accept] header into a

--- a/ietfparse/_helpers.py
+++ b/ietfparse/_helpers.py
@@ -1,38 +1,21 @@
 from __future__ import annotations
 
-from ietfparse import errors
-
 
 class ParameterParser:
     """Utility class to parse Link headers.
 
-    :param strict: controls whether parsing follows all of
-        the rules laid out in :rfc:`5988`
+    :param strict: controls whether parsing follows all
+        rules laid out in [RFC-8288-section-3]
 
-    This class parses the parameters for a single :mailheader:`Link`
+    This class parses the parameters for a single [HTTP-Link]
     value.  It is used from within the guts of
-    :function:`ietfparse.headers.parse_link_header` and not readily
-    suited for other uses.  If *strict mode* is enabled, then the
-    following rules from the RFC are obeyed:
+    [ietfparse.headers.parse_link_header][] and not readily
+    suited for other uses.
 
-    - section 5.3: when multiple "rel" attributes are present, then
-      the first one is chosen.  The remaining are omitted from the
-      value set.
-    - section 5.4: "there MUST NOT be more than one media parameter".
-      If more than one is present, then ``MalformedLinkValue`` is
-      raised.
-    - section 5.4: when multiple "type" attributes are present, then
-      the first one is chosen.  The remaining are omitted form the
-      value set.
-    - section 5.4: when multiple "title" attributes are present, then
-      the first one is chosen.  The remaining are omitted form the
-      value set.
-    - section 5.4: if both "title" and "title*" are present, then
-      "title*" is preferred.  The value of "title*" will be used
-      in all cases.
-    - section 5.4: "there MUST NOT be more than one type parameter".
-      If more than one is present, then ``MalformedLinkValue`` is
-      raised.
+    If *strict mode* is enabled, then the first value for the
+    `rel`, `media`, `type`, `title`, and `title*` parameters
+    is retained and additional values are ignored as described
+    in [RFC-8288-section-3].
 
     """
 
@@ -67,9 +50,6 @@ class ParameterParser:
             if self._rfc_values[name] is None:
                 self._rfc_values[name] = value
             elif self.strict:
-                if name in ('media', 'type'):
-                    msg = f'More than one {name} parameter present'
-                    raise errors.MalformedLinkValue(msg)
                 return
         except KeyError:
             pass

--- a/ietfparse/datastructures.py
+++ b/ietfparse/datastructures.py
@@ -156,6 +156,17 @@ class LinkHeader:
         self.target = target
         self.parameters = [] if parameters is None else parameters
 
+    @functools.cached_property
+    def rel(self) -> str:
+        """Space-separated relationship parameter.
+
+        This will be the empty string if the `rel` parameter
+        was not included.
+        """
+        return ' '.join(
+            value.strip() for name, value in self.parameters if name == 'rel'
+        ).strip()
+
     def __str__(self) -> str:
         formatted = f'<{self.target}>'
         if self.parameters:
@@ -168,10 +179,8 @@ class LinkHeader:
                     ]
                 )
             )
-            rel = [value for name, value in self.parameters if name == 'rel']
-            if rel:
-                joined = ' '.join(rel)
-                formatted += f'; rel="{joined}"'
+            if self.rel:
+                formatted += f'; rel="{self.rel}"'
             if params:
                 formatted += '; ' + params
 

--- a/ietfparse/datastructures.py
+++ b/ietfparse/datastructures.py
@@ -167,6 +167,16 @@ class LinkHeader:
             value.strip() for name, value in self.parameters if name == 'rel'
         ).strip()
 
+    def __getitem__(self, param_name: str) -> abc.Sequence[str]:
+        """Return the parameter values for `param_name` as a list.
+
+        If `param_name` is not present, then an empty sequence is returned.
+        """
+        return [value for name, value in self.parameters if name == param_name]
+
+    def __contains__(self, param_name: object) -> bool:
+        return param_name in {t[0] for t in self.parameters}
+
     def __str__(self) -> str:
         formatted = f'<{self.target}>'
         if self.parameters:

--- a/ietfparse/datastructures.py
+++ b/ietfparse/datastructures.py
@@ -168,13 +168,10 @@ class LinkHeader:
                     ]
                 )
             )
-            rel = [
-                f'{name}="{value}"'
-                for name, value in self.parameters
-                if name == 'rel'
-            ]
+            rel = [value for name, value in self.parameters if name == 'rel']
             if rel:
-                formatted += '; ' + rel[0]
+                joined = ' '.join(rel)
+                formatted += f'; rel="{joined}"'
             if params:
                 formatted += '; ' + params
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,32 +71,38 @@ python = "3.12"
 build-docs = [
 	"mkdocs build --strict --site-dir build/docs"
 ]
-ci = [
-	"pre-commit run --all-files",
-	"mypy --strict --package ietfparse --package tests",
-	"python -m coverage run -m pytest --junit-xml=test-results/junit.xml tests",
-	"python -m coverage xml",
-	"mkdir -p coverage",
-	"cp .coverage coverage/raw-{matrix:python:3.12}",
-]
-coverage = [
-	"python -m coverage run -m pytest tests",
-	"python -m coverage report",
-]
-coverage-report = [
-	"python -m coverage combine",
-	"python -m coverage report",
+build-report = [
+	"python -m coverage combine --data-file coverage/data coverage/data-*",
+	"python -m coverage report --data-file coverage/data",
+	"python -m coverage xml --data-file coverage/data -o coverage/coverage.xml",
 ]
 lint = [
 	"pre-commit run --all-files",
-	"mypy --strict --package ietfparse --package tests",
+	"mypy -p ietfparse -p tests",
 ]
+serve-docs = ["mkdocs serve -w ietfparse -w docs"]
 test = [
+	"pre-commit run --all-files",
+	"mypy -p ietfparse -p tests",
 	"python -m coverage run -m pytest tests",
 	"python -m coverage report"
 ]
 
-[[tool.hatch.envs.all.matrix]]
+[tool.hatch.envs.ci]
+dependencies = [
+	"coverage[toml]>=7.6",
+	"pytest>=7.1.2,<8",
+]
+
+[tool.hatch.envs.ci.scripts]
+test = [
+	"python -m coverage run -m pytest --junit-xml=test-results/junit.xml tests",
+	"python -m coverage xml",
+	"mkdir -p coverage",
+	"cp .coverage coverage/data-{matrix:python:3.12}",
+]
+
+[[tool.hatch.envs.ci.matrix]]
 python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.coverage.report]
@@ -106,6 +112,10 @@ show_missing = true
 [tool.coverage.run]
 branch = true
 source = ["ietfparse"]
+
+[tool.mypy]
+show_error_codes = true
+strict = true
 
 [tool.ruff]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ ci = [
 ]
 coverage = [
 	"python -m coverage run -m pytest tests",
+	"python -m coverage report",
 ]
 coverage-report = [
 	"python -m coverage combine",
@@ -99,6 +100,7 @@ test = [
 python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.coverage.report]
+exclude_also = ["if typing.TYPE_CHECKING"]
 show_missing = true
 
 [tool.coverage.run]

--- a/tests/test_headers_link.py
+++ b/tests/test_headers_link.py
@@ -161,3 +161,9 @@ class LinkHeaderFormattingTests(unittest.TestCase):
     def test_that_parameters_are_sorted_without_rel(self) -> None:
         parsed = headers.parse_link('<>; title=foo; hreflang="en"')
         self.assertEqual(str(parsed[0]), '<>; hreflang="en"; title="foo"')
+
+    def test_that_rels_are_combined_in_non_strict_mode(self) -> None:
+        parsed = headers.parse_link(
+            '<>; rel=one; rel=two; rel=three', strict=False
+        )
+        self.assertEqual(str(parsed[0]), '<>; rel="one two three"')

--- a/tests/test_headers_link.py
+++ b/tests/test_headers_link.py
@@ -86,6 +86,7 @@ class MalformedLinkHeaderTests(unittest.TestCase):
         parsed = headers.parse_link('<>; rel=first; rel=ignored')
         self.assertIn(('rel', 'first'), parsed[0].parameters)
         self.assertNotIn(('rel', 'ignored'), parsed[0].parameters)
+        self.assertEqual('first', parsed[0].rel)
 
     def test_that_first_media_parameters_is_used(self) -> None:
         # semantically malformed but handled appropriately
@@ -135,6 +136,7 @@ class MalformedLinkHeaderTests(unittest.TestCase):
         self.assertEqual(
             parsed[1].parameters, [('rel', 'first'), ('rel', 'second')]
         )
+        self.assertEqual(parsed[1].rel, 'first second')
         self.assertEqual(
             parsed[2].parameters, [('media', 'one'), ('media', 'two')]
         )
@@ -153,10 +155,12 @@ class LinkHeaderFormattingTests(unittest.TestCase):
     def test_that_rel_is_not_required(self) -> None:
         parsed = headers.parse_link('<>')
         self.assertEqual(str(parsed[0]), '<>')
+        self.assertEqual(parsed[0].rel, '')
 
     def test_that_only_first_rel_is_used(self) -> None:
         parsed = headers.parse_link('<>; rel=used; rel=first; rel=one')
         self.assertEqual(str(parsed[0]), '<>; rel="used"')
+        self.assertEqual(parsed[0].rel, 'used')
 
     def test_that_parameters_are_sorted_without_rel(self) -> None:
         parsed = headers.parse_link('<>; title=foo; hreflang="en"')
@@ -167,3 +171,4 @@ class LinkHeaderFormattingTests(unittest.TestCase):
             '<>; rel=one; rel=two; rel=three', strict=False
         )
         self.assertEqual(str(parsed[0]), '<>; rel="one two three"')
+        self.assertEqual(parsed[0].rel, 'one two three')

--- a/tests/test_headers_link.py
+++ b/tests/test_headers_link.py
@@ -70,6 +70,27 @@ class LinkHeaderParsingTests(unittest.TestCase):
         self.assertEqual('two', dict(parsed[1].parameters)['rel'])
         self.assertEqual('<two>; rel="two"', str(parsed[1]))
 
+    def test_indexed_access(self) -> None:
+        parsed = headers.parse_link(
+            '<>; rel=one; single=one; double=two; double="three"'
+        )
+        self.assertEqual(1, len(parsed))
+        link = parsed[0]
+        self.assertEqual(link['rel'], ['one'])
+        self.assertEqual(link['single'], ['one'])
+        self.assertEqual(link['double'], ['two', 'three'])
+        self.assertEqual(link['missing'], [])
+
+    def test_containment_check(self) -> None:
+        parsed = headers.parse_link('<>; rel=one')
+        self.assertEqual(1, len(parsed))
+
+        # ensure that these work as well... they will never
+        # return in the naive implementation of __getitem__
+        link = parsed[0]
+        self.assertIn('rel', link)
+        self.assertNotIn('missing', link)
+
 
 class MalformedLinkHeaderTests(unittest.TestCase):
     def test_that_value_error_when_url_brackets_are_missing(self) -> None:

--- a/tests/test_headers_link.py
+++ b/tests/test_headers_link.py
@@ -82,32 +82,38 @@ class MalformedLinkHeaderTests(unittest.TestCase):
 
     def test_that_first_rel_parameter_is_used(self) -> None:
         # semantically malformed but handled appropriately
-        # see RFC5988 sec. 5.3
+        # see RFC-8288 sec. 3.3
         parsed = headers.parse_link('<>; rel=first; rel=ignored')
         self.assertIn(('rel', 'first'), parsed[0].parameters)
         self.assertNotIn(('rel', 'ignored'), parsed[0].parameters)
 
-    def test_that_multiple_media_parameters_are_rejected(self) -> None:
-        with self.assertRaises(errors.MalformedLinkValue):
-            headers.parse_link('<first-link>; media=1; media=2')
+    def test_that_first_media_parameters_is_used(self) -> None:
+        # semantically malformed but handled appropriately
+        # see RFC-8288 sec. 3.4.1
+        parsed = headers.parse_link('<>; media=first; media=ignored')
+        self.assertIn(('media', 'first'), parsed[0].parameters)
+        self.assertNotIn(('media', 'ignored'), parsed[0].parameters)
 
     def test_that_first_title_parameter_is_used(self) -> None:
         # semantically malformed but handled appropriately
-        # see RFC5988 sec. 5.4
+        # see RFC-8288 sec. 3.4.1
         parsed = headers.parse_link('<>; title=first; title=ignored')
         self.assertIn(('title', 'first'), parsed[0].parameters)
         self.assertNotIn(('title', 'ignored'), parsed[0].parameters)
 
     def test_that_first_title_star_parameter_is_used(self) -> None:
         # semantically malformed but handled appropriately
-        # see RFC5988 sec. 5.4
+        # see RFC-8288 sec. 3.4.1
         parsed = headers.parse_link('<>; title*=first; title*=ignored')
         self.assertIn(('title*', 'first'), parsed[0].parameters)
         self.assertNotIn(('title*', 'ignored'), parsed[0].parameters)
 
-    def test_that_multiple_type_parameters_are_rejected(self) -> None:
-        with self.assertRaises(errors.MalformedLinkValue):
-            headers.parse_link('<>; type=1; type=2')
+    def test_that_the_first_type_parameters_is_used(self) -> None:
+        # semantically malformed but handled appropriately
+        # see RFC-8288 sec. 3.4.1
+        parsed = headers.parse_link('<>; type=first; type=ignored')
+        self.assertIn(('type', 'first'), parsed[0].parameters)
+        self.assertNotIn(('type', 'ignored'), parsed[0].parameters)
 
     def test_that_semantic_tests_can_be_turned_off(self) -> None:
         parsed = headers.parse_link(

--- a/tests/test_headers_link.py
+++ b/tests/test_headers_link.py
@@ -123,6 +123,21 @@ class MalformedLinkHeaderTests(unittest.TestCase):
             strict=False,
         )
         self.assertEqual(len(parsed), 3)
+        self.assertEqual(
+            parsed[0].parameters,
+            [
+                ('title', 'one'),
+                ('title', 'two'),
+                ('title*', 'three'),
+                ('title*', 'four'),
+            ],
+        )
+        self.assertEqual(
+            parsed[1].parameters, [('rel', 'first'), ('rel', 'second')]
+        )
+        self.assertEqual(
+            parsed[2].parameters, [('media', 'one'), ('media', 'two')]
+        )
 
 
 class LinkHeaderFormattingTests(unittest.TestCase):


### PR DESCRIPTION
This PR changes the `LinkHeader` datastructure quite a bit and **introduces breaking changes** in there.

I added `rel` as a property since constantly writing loops or comprehensions to extract it is painful.

I also made parameter lookup more efficient and accessible. Parameters are accessible as items (eg, `link['rel']`) with indexed access returning an empty collection for undefined parameters. _I'm not so sure that I like returning an empty collection instead of raising `KeyError` so it may change in the future._

The `LinkHeader` instance is now immutable which makes the multiple ways to get to parameters consistent and efficient. This is the breaking change since previously you could modify the `parameters` list or the `target` property. Both of these are hidden behind `@property`-decorated methods now.