### PR TITLE
Add MalformedContentType exception

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -13,6 +13,7 @@
 
 ::: ietfparse.errors.RootException
 ::: ietfparse.errors.NoMatch
+::: ietfparse.errors.MalformedContentType
 ::: ietfparse.errors.MalformedLinkValue
 ::: ietfparse.errors.StrictHeaderParsingFailure
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,8 @@
 - `datastructures.LinkHeader.rel` property
 - indexed parameter lookup in `datastructures.LinkHeader`
 - `datastructures.ImmutableSequence` helper class
+- `errors.MalformedContentType` exception explicitly identifies [HTTP-Content-Type]
+  parsing failures. It is a subclass of `ValueError` for the sake of compatability.
 
 ### Changed
 
@@ -33,6 +35,8 @@
   | parse_link         | strict                     |
 
 - switched from sphinx to mkdocs
+- `headers.parse_content_type` changed to raise `MalformedContentType` error
+  instead of `ValueError`.
 
 
 ### Removed

--- a/ietfparse/errors.py
+++ b/ietfparse/errors.py
@@ -1,7 +1,7 @@
 """Exceptions raised from within ietfparse.
 
-All exceptions are rooted at :class:`~ietfparse.errors.RootException` so
-so you can catch it to implement error handling behavior associated with
+All exceptions are rooted at [ietfparse.errors.RootException][], so
+you can catch it to implement error handling behavior associated with
 this library's functionality.
 
 """
@@ -34,3 +34,10 @@ class StrictHeaderParsingFailure(RootException, ValueError):
         super().__init__(header_name, header_value)
         self.header_name = header_name
         self.header_value = header_value
+
+
+class MalformedContentType(StrictHeaderParsingFailure):
+    """Attempted to parse a malformed [HTTP-Content-Type] header."""
+
+    def __init__(self, header_value: str) -> None:
+        super().__init__('content-type', header_value)

--- a/ietfparse/headers.py
+++ b/ietfparse/headers.py
@@ -224,8 +224,8 @@ def parse_content_type(
         compliance in which content parameter values are case
         preserving.
     :return: the parsed content type
-    :raise ValueError: if the content type cannot be reasonably
-        parsed (e.g., ``Content-Type: *``)
+    :raise ietfparse.errors.MalformedContentType:
+        if the content type cannot be parsed (eg, `Content-Type: *`)
 
     """
     parts = _remove_comments(content_type).split(';')
@@ -233,7 +233,7 @@ def parse_content_type(
     try:
         content_type, content_subtype = type_spec.split('/')
     except ValueError as error:
-        raise ValueError(f'Failed to parse {type_spec}') from error
+        raise errors.MalformedContentType(content_type) from error
 
     parameters = _parse_parameter_list(
         parts, normalize_parameter_values=normalize_parameter_values

--- a/tests/test_headers_content_type.py
+++ b/tests/test_headers_content_type.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ietfparse import datastructures, headers
+from ietfparse import datastructures, errors, headers
 
 
 class SimpleContentTypeParsingTests(unittest.TestCase):
@@ -49,7 +49,7 @@ class ParsingComplexContentTypeTests(unittest.TestCase):
 
 class ParsingBrokenContentTypes(unittest.TestCase):
     def test_that_missing_subtype_raises_value_error(self) -> None:
-        with self.assertRaises(ValueError):
+        with self.assertRaises(errors.MalformedContentType):
             headers.parse_content_type('*')
 
 


### PR DESCRIPTION
This PR adds a new exception class that explicitly identifies `Content-Type` parsing failures. Previously `parse_content_type` raised a generic `ValueError` which could have multiple sources. The new exception class `MalformedContentType` is a sub-class of `ValueError` so client code does not require changes; however, you can now tighten up exception handling if you wish.