### PR TITLE
Allow passing unparsed parameters to select_content_type

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2022, Dave Shawley
+Copyright (c) 2014-2024, Dave Shawley
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -21,21 +21,152 @@ Internet world.
 Here's a sample of the code that this library lets you write:
 
 ```python
-from ietfparse import algorithms, headers
+import json
+import typing
 
-def negotiate_versioned_representation(request, handler, data_dict):
-    requested = headers.parse_accept(request.headers['accept'])
-    selected, _ = algorithms.select_content_type(requested, [
-        headers.parse_content_type('application/example+json; v=1'),
-        headers.parse_content_type('application/example+json; v=2'),
-        headers.parse_content_type('application/json'),
-    ])
+from ietfparse import algorithms, constants
 
-    output_version = selected.parameters.get('v', '2')
-    if output_version == '1':
-        handler.set_header('Content-Type', 'application/example+json; v=1')
-        handler.write(generate_legacy_json(data_dict))
-    else:
-        handler.set_header('Content-Type', 'application/example+json; v=2')
-        handler.write(generate_modern_json(data_dict))
+default_content_type = constants.APPLICATION_JSON
+supported = [constants.APPLICATION_JSON, constants.TEXT_HTML]
+
+def render_widget(request, widget):
+    """Render `widget` based on the accept header"""
+    selected, requested = algorithms.select_content_type(
+        request.headers.get('accept') or default_content_type,
+        supported, default=default_content_type)
+    match selected:
+        case constants.APPLICATION_JSON:
+            body = json.dumps(widget)
+        case constants.TEXT_HTML:
+            body = translate_to_html(widget)
+        case _ as unreachable:
+            typing.assert_never(unreachable)
+
+    return Response(body=body, content_type=str(requested))
 ```
+
+The `render_widget` function is an implementation of _Proactive Content Negotiation_
+as described in [RFC-9110]. It calls `select_content_type` function to determine the
+most appropriate content type based on the [Accept] header from the request and the
+list of content types that the application supports. Then it renders `widget` in
+the selected format.
+
+As usual, the devil is in the details. This library understands how to parse HTTP
+headers into _datastructures_ and contains _algorithms_ that do useful things with
+the parsed values. The datastructures themselves hide a lot of useful functionality.
+Consider the [HTTP Link header] that is synonymous with REST APIs. Links between
+resources are represented as a target URL and a _relationship type_. Consider an
+implementation of paging through a search result set. A naive implementation places
+the onus on the client to select each page by iteratively sending requests with the
+page number in the request.
+
+    GET /search?q=...&page-size=100
+    GET /search?q=...&page=1&page-size=100
+    GET /search?q=...&page=2&page-size=100
+
+The client knows that it is "done" when it gets an empty response. Despite its
+simplicity, this approach has a few drawbacks. The largest is that every client has
+intimate knowledge of the query parameters and how to go from one response to the
+next request. This is a common web antipattern that you probably recognize. If you
+have been on the implementation side of search endpoint for a large dataset using
+an SQL backend, then you may have run into the performance problems associated with
+using `SELECT ... WHERE ... OFFSET {page} LIMIT {size}` style query.
+
+> What happens when we change the pattern from offset and page size to use a
+> server-side cursor?
+
+The short answer is that we have to change _every client implementation_. The next
+iteration is usually to add pagination information into the response structure.
+Something like:
+
+```json
+{
+  "data": [],
+  "paging": {
+    "total": 1234,
+    "next": "/search?q=...&page=4&page-size=100",
+    "previous": "/search?q=...&page=3&page-size=100",
+    "first": "/search?q=..."
+  }
+}
+```
+
+Now our clients can follow links embedded in the response structure and the server
+is completely in control of the pagination API. If the traversal algorithm changes
+to pass a cursor in the URL, then it simply changes the links between pages in the
+response. This is at the core of what Roy Fielding termed the Representational State
+Transfer interaction pattern. There is still a problem in here ... clients need to
+parse metadata from the responses. In essence, they have to separate the data and
+the pagination data in the response. The [HTTP Link header] is used to move the
+links between representations out of the body and into HTTP headers.
+
+```
+GET /search?q=...&page=3&page-size=100 HTTP/1.1
+Accept: application/json, application/msgpack;q=0.7
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+Link: </search?q=...&page=4&page-size=100>; rel="next"
+Link: </search?q=...&page=4&page-size=100>; rel="next"
+Link: </search?q=...&page=4&page-size=100>; rel="previous"
+Link: </search?q=...>; rel="first"
+
+[]
+```
+
+Now the response is simply a list of items found. Much easier to handle on the
+client side of things. However, `Link` headers have a complex syntax so parsing
+them requires some work. In addition to the individual header values, they can
+be combined into a single `Link` header contain a comma-separated list of values.
+The `headers.parse_link` function transforms a `Link` header into a list of
+datastructures that make accessing the individual properties simple.
+
+```pycon
+>>> from ietfparse import headers
+>>> links = headers.parse_link('</search?q=...&page=4&page-size=100>; rel="next"')
+>>> len(links)
+1
+>>> links[0].rel
+'next'
+>>> links[0].target
+'/search?q=...&page=4&page-size=100'
+>>> str(links[0])
+'</search?q=...&page=4&page-size=100>; rel="next"'
+>>> links[0]
+<ietfparse.datastructures.LinkHeader object at 0x100ad0620>
+```
+
+The `datastructures.LinkHeader` class is also useful for generating link
+headers.
+
+```pycon
+>>> from iefparse import datastructures
+>>> next_page = datastructures.LinkHeader(
+...    '/search?q=...&page=4&page-size=100',
+...    [('rel', 'next')])
+>>> str(next_page)
+'</search?q=...&page=4&page-size=100>; rel="next"'
+```
+
+Single link values are _pretty simple_. They get more complicated with the
+addition of properties. The `LinkHeader` instance knows how to correctly
+format property values contain various problematic characters so that you
+do not need to be an expert.
+
+The `Link` header is one of the many headers supported by this library. See
+the [API Documentation] for a complete (and up tp date) list.
+
+*  [RFC-9110: Accept](https://www.rfc-editor.org/rfc/rfc9110#field.accept)
+*  [RFC-9110: Accept-Charset](https://www.rfc-editor.org/rfc/rfc9110#field.accept-charset)
+*  [RFC-9110: Accept-Encoding](https://www.rfc-editor.org/rfc/rfc9110#field.accept-encoding)
+*  [RFC-9110: Accept-Language](https://www.rfc-editor.org/rfc/rfc9110#field.accept-language)
+*  [RFC-9111: Cache-Control](https://www.rfc-editor.org/rfc/rfc9111#field.cache-control)
+*  [RFC-9110: Content-Type](https://www.rfc-editor.org/rfc/rfc9110#field.content-type)
+*  [RFC-7239: Forwarded](https://www.rfc-editor.org/rfc/rfc7239)
+*  [RFC-8288: Link](https://www.rfc-editor.org/rfc/rfc8288)
+
+
+[API Documentation]: https://ietfparse.readthedocs.io/en/latest/?badge=latest
+[Accept]: https://www.rfc-editor.org/rfc/rfc9110#field.accept
+[HTTP Link header]: https://www.rfc-editor.org/rfc/rfc8288
+[RFC-9110]: https://www.rfc-editor.org/rfc/rfc9110#name-proactive-negotiation

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4,6 +4,18 @@
 
 ::: ietfparse.algorithms.select_content_type
 
+## ietfparse.constants
+
+This module contains some useful constant values for using alongside
+[ietfparse.datastructures.ContentType][] instances or as parameters to the
+[ietfparse.algorithms.select_content_type][] function. These are cherry-picked from the
+[IANA Media Types registry](https://www.iana.org/assignments/media-types/media-types.xhtml).
+
+::: ietfparse.constants
+    options:
+      summary:
+        attributes: true
+
 ## ietfparse.datastructures
 
 ::: ietfparse.datastructures.ContentType

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@
 
 ### Added
 
+- `ietfparse.constants` module -- _this contains constant ContentType instances_
 - [pre-commit](https://pre-commit.com/) utility usage
 - `datastructures.LinkHeader.rel` property
 - indexed parameter lookup in `datastructures.LinkHeader`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,15 @@
 ### Breaking Changes
 
 - `datastructures.LinkHeader` is now immutable
+- converted positional Boolean parameters to keyword-only parameters
+
+  | Function           | Parameter                  |
+  |--------------------|----------------------------|
+  | parse_accept       | strict                     |
+  | parse_content_type | normalize_parameter_values |
+  | parse_forwarded    | only_standard_parameters   |
+  | parse_link         | strict                     |
+
 
 ### Added
 
@@ -25,18 +34,10 @@
   [RFC-8288-section-3]. Note that this is only relevant if you disable strict
   mode parsing.
 - replaced setuptools with [hatch](https://hatch.pypa.io/)
-- converted positional Boolean parameters to keyword-only parameters
-
-  | Function           | Parameter                  |
-  |--------------------|----------------------------|
-  | parse_accept       | strict                     |
-  | parse_content_type | normalize_parameter_values |
-  | parse_forwarded    | only_standard_parameters   |
-  | parse_link         | strict                     |
-
 - switched from sphinx to mkdocs
 - `headers.parse_content_type` changed to raise `MalformedContentType` error
   instead of `ValueError`.
+- `datastructures.ContentType` instances can now be compared to strings
 
 
 ### Removed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,7 @@
 - `datastructures.ImmutableSequence` helper class
 - `errors.MalformedContentType` exception explicitly identifies [HTTP-Content-Type]
   parsing failures. It is a subclass of `ValueError` for the sake of compatability.
+- `default` parameter to `algorithms.select_content_type`
 
 ### Changed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,8 @@
 - `headers.parse_content_type` changed to raise `MalformedContentType` error
   instead of `ValueError`.
 - `datastructures.ContentType` instances can now be compared to strings
+- `algorithms.select_content_type` changed to accept strings as well as `ContentType`
+  instances
 
 
 ### Removed

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,37 +6,166 @@ hide:
 ---
 # ietfparse
 
-This is a gut reaction to the wealth of ways to parse URLs, MIME headers,
-HTTP messages and other things described by IETF RFCs.  They range from
-the Python standard library (`urllib`) to be buried in the guts of other
+[![PyPI - Version](https://img.shields.io/pypi/v/ietfparse)](https://pypi.org/project/ietfparse/)
+[![Documentation Status](https://readthedocs.org/projects/ietfparse/badge/?version=latest)](https://ietfparse.readthedocs.io/en/latest/?badge=latest)
+[![Circle-CI](https://circleci.com/gh/dave-shawley/ietfparse.svg?style=shield)](https://circleci.com/gh/dave-shawley/ietfparse)
+![Code Climate coverage](https://img.shields.io/codeclimate/coverage/dave-shawley/ietfparse)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=dave-shawley_ietfparse&metric=alert_status)](https://sonarcloud.io/summary/overall?id=dave-shawley_ietfparse)
+
+This project is a gut reaction to the wealth of ways to parse URLs, MIME
+headers, HTTP messages and other things described by IETF RFCs. They range
+from the Python standard library (`urllib`) to be buried in the guts of other
 *kitchen sink* libraries (`werkzeug`) and most of them are broken in one
 way or the other.
 
-So why create another one?  Good question... glad that you asked.  This is
+So why create another one?  *Good question...* glad that you asked. This is
 a companion library to the great packages out there that are responsible for
-communicating with other systems.  I'm going to concentrate on providing a
-crisp and usable set of APIs that concentrate on parsing text.  Nothing more.
+communicating with other systems. I'm going to concentrate on providing a
+crisp and usable set of APIs that concentrate on parsing text. Nothing more.
 Hopefully by concentrating on the specific task of parsing things, the result
 will be a beautiful and usable interface to the text strings that power the
 Internet world.
 
-Here's a sample of the code that this library lets you write::
+Here's a sample of the code that this library lets you write:
+
 ```python
-from ietfparse import algorithms, headers
+import json
+import typing
 
-def negotiate_versioned_representation(request, handler, data_dict):
-    requested = headers.parse_accept(request.headers['accept'])
-    selected, _ = algorithms.select_content_type(requested, [
-        headers.parse_content_type('application/example+json; v=1'),
-        headers.parse_content_type('application/example+json; v=2'),
-        headers.parse_content_type('application/json'),
-    ])
+from ietfparse import algorithms, constants
 
-    output_version = selected.parameters.get('v', '2')
-    if output_version == '1':
-        handler.set_header('Content-Type', 'application/example+json; v=1')
-        handler.write(generate_legacy_json(data_dict))
-    else:
-        handler.set_header('Content-Type', 'application/example+json; v=2')
-        handler.write(generate_modern_json(data_dict))
+default_content_type = constants.APPLICATION_JSON
+supported = [constants.APPLICATION_JSON, constants.TEXT_HTML]
+
+def render_widget(request, widget):
+    """Render `widget` based on the accept header"""
+    selected, requested = algorithms.select_content_type(
+        request.headers.get('accept') or default_content_type,
+        supported, default=default_content_type)
+    match selected:
+        case constants.APPLICATION_JSON:
+            body = json.dumps(widget)
+        case constants.TEXT_HTML:
+            body = translate_to_html(widget)
+        case _ as unreachable:
+            typing.assert_never(unreachable)
+
+    return Response(body=body, content_type=str(requested))
 ```
+
+The `render_widget` function is an implementation of _Proactive Content Negotiation_
+as described in [RFC-9110]. It calls [ietfparse.algorithms.select_content_type][]
+function to determine the most appropriate content type based on the [HTTP-Accept]
+header from the request and the list of content types that the application supports.
+Then it renders `widget` in the selected format.
+
+As usual, the devil is in the details. This library understands how to parse HTTP
+headers into _datastructures_ and contains _algorithms_ that do useful things with
+the parsed values. The datastructures themselves hide a lot of useful functionality.
+Consider the [HTTP-Link] header that is synonymous with REST APIs. Links between
+resources are represented as a target URL and a _relationship type_. Consider an
+implementation of paging through a search result set. A naive implementation places
+the onus on the client to select each page by iteratively sending requests with the
+page number in the request.
+
+    GET /search?q=...&page-size=100
+    GET /search?q=...&page=1&page-size=100
+    GET /search?q=...&page=2&page-size=100
+
+The client knows that it is "done" when it gets an empty response. Despite its
+simplicity, this approach has a few drawbacks. The largest is that every client has
+intimate knowledge of the query parameters and how to go from one response to the
+next request. This is a common web antipattern that you probably recognize. If you
+have been on the implementation side of search endpoint for a large dataset using
+an SQL backend, then you may have run into the performance problems associated with
+using `SELECT ... WHERE ... OFFSET {page} LIMIT {size}` style query.
+
+> What happens when we change the pattern from offset and page size to use a
+> server-side cursor?
+
+The short answer is that we have to change _every client implementation_. The next
+iteration is usually to add pagination information into the response structure.
+Something like:
+
+```json
+{
+  "data": [],
+  "paging": {
+    "total": 1234,
+    "next": "/search?q=...&page=4&page-size=100",
+    "previous": "/search?q=...&page=3&page-size=100",
+    "first": "/search?q=..."
+  }
+}
+```
+
+Now our clients can follow links embedded in the response structure and the server
+is completely in control of the pagination API. If the traversal algorithm changes
+to pass a cursor in the URL, then it simply changes the links between pages in the
+response. This is at the core of what Roy Fielding termed the Representational State
+Transfer interaction pattern. There is still a problem in here ... clients need to
+parse metadata from the responses. In essence, they have to separate the data and
+the pagination data in the response. The [HTTP-Link] header is used to move the
+links between representations out of the body and into HTTP headers.
+
+```
+GET /search?q=...&page=3&page-size=100 HTTP/1.1
+Accept: application/json, application/msgpack;q=0.7
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+Link: </search?q=...&page=4&page-size=100>; rel="next"
+Link: </search?q=...&page=4&page-size=100>; rel="next"
+Link: </search?q=...&page=4&page-size=100>; rel="previous"
+Link: </search?q=...>; rel="first"
+
+[]
+```
+
+Now the response is simply a list of items found. Much easier to handle on the
+client side of things. However, `Link` headers have a complex syntax so parsing
+them requires some work. In addition to the individual header values, they can
+be combined into a single `Link` header contain a comma-separated list of values.
+The [ietfparse.headers.parse_link][] function transforms a `Link` header into a
+list of datastructures that make accessing the individual properties simple.
+
+```pycon
+>>> from ietfparse import headers
+>>> links = headers.parse_link('</search?q=...&page=4&page-size=100>; rel="next"')
+>>> len(links)
+1
+>>> links[0].rel
+'next'
+>>> links[0].target
+'/search?q=...&page=4&page-size=100'
+>>> str(links[0])
+'</search?q=...&page=4&page-size=100>; rel="next"'
+>>> links[0]
+<ietfparse.datastructures.LinkHeader object at 0x100ad0620>
+```
+
+The [ietfparse.datastructures.LinkHeader][] class is also useful for generating link
+headers.
+
+```pycon
+>>> from iefparse import datastructures
+>>> next_page = datastructures.LinkHeader(
+...    '/search?q=...&page=4&page-size=100',
+...    [('rel', 'next')])
+>>> str(next_page)
+'</search?q=...&page=4&page-size=100>; rel="next"'
+```
+
+Single link values are _pretty simple_. They get more complicated with the
+addition of properties. The `LinkHeader` instance knows how to correctly
+format property values contain various problematic characters so that you
+do not need to be an expert.
+
+The `Link` header is one of the many headers supported by this library. See
+the [Header Parsing](header-parsing.md) section for a complete (and up tp date) list.
+
+
+[API Documentation]: https://ietfparse.readthedocs.io/en/latest/?badge=latest
+[Accept]: https://www.rfc-editor.org/rfc/rfc9110#field.accept
+[HTTP Link header]: https://www.rfc-editor.org/rfc/rfc8288
+[RFC-9110]: https://www.rfc-editor.org/rfc/rfc9110#name-proactive-negotiation

--- a/ietfparse/_helpers.py
+++ b/ietfparse/_helpers.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+import typing
+
+from ietfparse import headers
+
+if typing.TYPE_CHECKING:
+    from collections import abc
+
+    from ietfparse import datastructures
+
 
 class ParameterParser:
     """Utility class to parse Link headers.
@@ -73,3 +82,30 @@ class ParameterParser:
             elif fallback_title is not None:
                 values.append(('title', fallback_title))
         return values
+
+
+@typing.overload
+def parse_header(
+    parser_name: typing.Literal['parse_accept'], value: str
+) -> abc.Sequence[datastructures.ContentType]: ...
+
+
+@typing.overload
+def parse_header(
+    parser_name: typing.Literal['parse_content_type'], value: str
+) -> datastructures.ContentType: ...
+
+
+@typing.overload
+def parse_header(
+    parser_name: typing.Literal['parse_link'], value: str
+) -> abc.Sequence[datastructures.LinkHeader]: ...
+
+
+def parse_header(parser_name: str, value: str) -> object:
+    try:
+        return getattr(headers, parser_name)(value)
+    except AttributeError:
+        raise NotImplementedError(f'unknown parser {parser_name}') from None
+    except ValueError:
+        return value

--- a/ietfparse/constants.py
+++ b/ietfparse/constants.py
@@ -1,0 +1,70 @@
+"""Useful constant values.
+
+!!! warning
+
+    Take care when comparing content type values since equality comparison
+    includes comparing parameter values. The
+    [ietfparse.algorithms.select_content_type][] algorithm should be used
+    to select content type based on the [HTTP-Accept] header.
+
+    ```pycon
+    >>> from ietfparse import headers
+    >>> a = headers.parse_content_type('application/json')
+    >>> b = headers.parse_content_type('application/json; charset=utf-8')
+    >>> c = headers.parse_content_type('application/json; charset="UTF-8"')
+    >>> a == b
+    False
+    >>> a == c
+    False
+    >>> b == c
+    True
+    ```
+
+    The last example shows that parameters are normalized when parsing.
+
+"""
+
+from ietfparse import datastructures as ds
+from ietfparse import headers
+
+APPLICATION_JSON: ds.ContentType = headers.parse_content_type(
+    'application/json'
+)
+"""[RFC-8259]: The JavaScript Object Notation (JSON) Data Interchange Format"""
+
+APPLICATION_OCTET_STREAM: ds.ContentType = headers.parse_content_type(
+    'application/octet-stream'
+)
+"""Default content type for the Internet as described in [RFC=2045]"""
+
+APPLICATION_PROBLEM_JSON: ds.ContentType = headers.parse_content_type(
+    'application/problem+json'
+)
+"""HTTP API error document as described by [RFC-9457]"""
+
+APPLICATION_XML: ds.ContentType = headers.parse_content_type('application/xml')
+"""eXtensible Markup Language as described in [RFC-7303]"""
+
+TEXT_HTML: ds.ContentType = headers.parse_content_type(
+    'text/html; charset=UTF-8'
+)
+"""[HyperText Markup Language](https://html.spec.whatwg.org/multipage/)"""
+
+TEXT_JAVASCRIPT: ds.ContentType = headers.parse_content_type(
+    'text/javascript; charset=UTF-8'
+)
+"""ECMAScript Media Types ([RFC-9239])"""
+
+TEXT_MARKDOWN: ds.ContentType = headers.parse_content_type(
+    'text/markdown; charset=UTF-8'
+)
+"""Markdown documents ([RFC-7763])
+
+RFC-7763 is the formal registration for Markdown formatted content.
+[Daring Fireball: Markdown](http://daringfireball.net/projects/markdown/)
+is the document specification.
+"""
+
+TEXT_PLAIN: ds.ContentType = headers.parse_content_type('text/plain')
+"""Simple text content encoded in UTF-8 characters
+([RFC-2046-section-4.1.3])"""

--- a/ietfparse/datastructures.py
+++ b/ietfparse/datastructures.py
@@ -17,6 +17,8 @@ import functools
 import typing
 from collections import abc
 
+from ietfparse import _helpers
+
 
 @functools.total_ordering
 class ContentType:
@@ -101,6 +103,8 @@ class ContentType:
         )
 
     def __eq__(self, other: object) -> bool:
+        if isinstance(other, str):
+            other = _helpers.parse_header('parse_content_type', other)
         if not isinstance(other, ContentType):
             return NotImplemented
         return (
@@ -111,6 +115,8 @@ class ContentType:
         )
 
     def __lt__(self, other: object) -> bool:
+        if isinstance(other, str):
+            other = _helpers.parse_header('parse_content_type', other)
         if not isinstance(other, ContentType):
             return NotImplemented
         if self.content_type == '*' and other.content_type != '*':

--- a/ietfparse/headers.py
+++ b/ietfparse/headers.py
@@ -73,6 +73,7 @@ def parse_accept(  # noqa: C901 -- overly complex
         [ietfparse.headers.parse_content_type][]
 
     """
+    guard: contextlib.AbstractContextManager[None]
     if strict:
         guard = contextlib.nullcontext()
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,10 @@ test = [
 python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.coverage.report]
-exclude_also = ["if typing.TYPE_CHECKING"]
+exclude_also = [
+	"if typing.TYPE_CHECKING",
+	"\\.\\.\\."
+]
 show_missing = true
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,14 +32,14 @@ Maintainability = "https://codeclimate.com/github/dave-shawley/ietfparse/"
 
 [project.optional-dependencies]
 dev = [
-	"coverage[toml]>=7.6",
+	"coverage[toml]>=7.6,<8",
 	"mkdocs-material>=9.5.42,<10",
 	"mkdocstrings[python]>=0.26.2,<0.27",
-	"mypy==0.910",
+	"mypy>=1.13,<2",
 	"pre-commit>=4.0.1,<5",
 	"pymdown-ietflinks==0.0.0; python_version >= '3.12'",
-	"pytest>=7.1.2,<8",
-	"ruff==0.6.9",
+	"pytest>=8.3,<9",
+	"ruff>=0.7,<0.8",
 ]
 
 [build-system]

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -94,6 +94,23 @@ class ProactiveContentNegotiationTests(ContentNegotiationTestCase):
                 [headers.parse_content_type('image/png')],
             )
 
+    def test_that_default_is_returned_when_appropriate(self) -> None:
+        selected, matched = algorithms.select_content_type(
+            headers.parse_accept('text/html'),
+            ['application/json', 'application/msgpack'],
+            default='application/msgpack',
+        )
+        self.assertEqual(selected, 'application/msgpack')
+        self.assertEqual(matched, 'application/msgpack')
+
+    def test_that_default_is_required_to_be_available(self) -> None:
+        with self.assertRaises(ValueError):
+            algorithms.select_content_type(
+                'text/html',
+                ['application/json'],
+                default='application/msgpack',
+            )
+
 
 class Rfc7231ExampleTests(ContentNegotiationTestCase):
     @classmethod

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -131,7 +131,7 @@ class Rfc7231ExampleTests(ContentNegotiationTestCase):
         )
 
 
-class PriorizationTests(unittest.TestCase):
+class PrioritizationTests(unittest.TestCase):
     def test_that_explicit_priority_1_is_preferred(self) -> None:
         selected, matched = algorithms.select_content_type(
             headers.parse_accept(
@@ -175,3 +175,22 @@ class PriorizationTests(unittest.TestCase):
         self.assertEqual(
             str(selected), 'application/vnd.com.example+json; version=1'
         )
+
+
+class StringBasedTests(unittest.TestCase):
+    def test_that_select_content_type_parses_accept_header(self) -> None:
+        selected, _ = algorithms.select_content_type(
+            'text/html, text/plain;q=0.2',
+            [
+                headers.parse_content_type(value)
+                for value in ['text/html', 'text/plain']
+            ],
+        )
+        self.assertEqual(str(selected), 'text/html')
+
+    def test_that_select_content_type_parses_strings(self) -> None:
+        selected, _ = algorithms.select_content_type(
+            ['text/html', 'text/plain'],
+            ['application/json', 'text/html', 'text/plain'],
+        )
+        self.assertEqual(str(selected), 'text/html')

--- a/tests/test_datastructure.py
+++ b/tests/test_datastructure.py
@@ -1,6 +1,9 @@
 import unittest
 
-from ietfparse import datastructures
+from ietfparse import (
+    constants,  # noqa: F401 -- imported for coverage
+    datastructures,
+)
 
 
 class ContentTypeCreationTests(unittest.TestCase):

--- a/tests/test_datastructure.py
+++ b/tests/test_datastructure.py
@@ -1,128 +1,130 @@
 import unittest
 
-from ietfparse.datastructures import ContentType
+from ietfparse import datastructures
 
 
 class ContentTypeCreationTests(unittest.TestCase):
     def test_that_primary_type_is_normalized(self) -> None:
-        self.assertEqual(
-            'contenttype', ContentType('COntentType', 'b').content_type
-        )
+        content_type = datastructures.ContentType('COntentType', 'b')
+        self.assertEqual('contenttype', content_type.content_type)
 
     def test_that_subtype_is_normalized(self) -> None:
-        self.assertEqual(
-            'subtype', ContentType('a', '  SubType  ').content_subtype
-        )
+        content_type = datastructures.ContentType('a', '  SubType  ')
+        self.assertEqual('subtype', content_type.content_subtype)
 
     def test_that_content_suffix_is_normalized(self) -> None:
-        self.assertEqual(
-            'json',
-            ContentType('a', 'b', content_suffix=' JSON').content_suffix,
+        content_type = datastructures.ContentType(
+            'a', 'b', content_suffix=' JSON'
         )
+        self.assertEqual('json', content_type.content_suffix)
 
     def test_that_parameter_names_are_casefolded(self) -> None:
-        self.assertDictEqual(
-            {'key': 'Value'},
-            ContentType(
-                'a',
-                'b',
-                parameters={
-                    'KEY': 'Value',
-                },
-            ).parameters,
+        content_type = datastructures.ContentType(
+            'a', 'b', parameters={'KEY': 'Value'}
         )
+        self.assertDictEqual({'key': 'Value'}, content_type.parameters)
 
 
 class ContentTypeStringificationTests(unittest.TestCase):
     def test_that_simple_case_works(self) -> None:
-        self.assertEqual(
-            'primary/subtype', str(ContentType('primary', 'subtype'))
-        )
+        content_type = datastructures.ContentType('primary', 'subtype')
+        self.assertEqual('primary/subtype', str(content_type))
 
     def test_that_parameters_are_sorted_by_name(self) -> None:
-        ct = ContentType('a', 'b', {'one': '1', 'two': '2', 'three': 3})
+        ct = datastructures.ContentType(
+            'a', 'b', {'one': '1', 'two': '2', 'three': 3}
+        )
         self.assertEqual('a/b; one=1; three=3; two=2', str(ct))
 
     def test_that_content_suffix_is_appended(self) -> None:
-        ct = ContentType('a', 'b', {'foo': 'bar'}, content_suffix='xml')
+        ct = datastructures.ContentType(
+            'a', 'b', {'foo': 'bar'}, content_suffix='xml'
+        )
         self.assertEqual('a/b+xml; foo=bar', str(ct))
 
 
 class ContentTypeComparisonTests(unittest.TestCase):
     def test_type_equals_itself(self) -> None:
-        self.assertEqual(ContentType('a', 'b'), ContentType('a', 'b'))
+        ct1 = datastructures.ContentType('a', 'b')
+        ct2 = datastructures.ContentType('a', 'b')
+        self.assertEqual(ct1, ct2)
 
     def test_that_differing_types_are_not_equal(self) -> None:
-        self.assertNotEqual(ContentType('a', 'b'), ContentType('b', 'a'))
+        ct1 = datastructures.ContentType('a', 'b')
+        ct2 = datastructures.ContentType('b', 'a')
+        self.assertNotEqual(ct1, ct2)
 
     def test_that_differing_suffixes_are_not_equal(self) -> None:
-        self.assertNotEqual(
-            ContentType('a', 'b', content_suffix='1'),
-            ContentType('a', 'b', content_suffix='2'),
-        )
+        ct1 = datastructures.ContentType('a', 'b', content_suffix='1')
+        ct2 = datastructures.ContentType('a', 'b', content_suffix='2')
+        self.assertNotEqual(ct1, ct2)
 
     def test_that_differing_params_are_not_equal(self) -> None:
-        self.assertNotEqual(
-            ContentType('a', 'b', parameters={'one': '1'}),
-            ContentType('a', 'b'),
-        )
+        ct1 = datastructures.ContentType('a', 'b', parameters={'one': '1'})
+        ct2 = datastructures.ContentType('a', 'b')
+        self.assertNotEqual(ct1, ct2)
 
     def test_that_case_is_ignored_when_comparing_types(self) -> None:
-        self.assertEqual(
-            ContentType('text', 'html', {'level': '3.2'}, 'json'),
-            ContentType('Text', 'Html', {'Level': '3.2'}, 'JSON'),
+        ct1 = datastructures.ContentType(
+            'text', 'html', {'level': '3.2'}, 'json'
         )
+        ct2 = datastructures.ContentType(
+            'Text', 'Html', {'Level': '3.2'}, 'JSON'
+        )
+        self.assertEqual(ct1, ct2)
 
     def test_primary_wildcard_is_less_than_anything_else(self) -> None:
-        self.assertLess(ContentType('*', '*'), ContentType('text', 'plain'))
-        self.assertLess(ContentType('*', '*'), ContentType('text', '*'))
+        wildcard = datastructures.ContentType('*', '*')
+        text_plain = datastructures.ContentType('text', 'plain')
+        text_wildcard = datastructures.ContentType('text', '*')
+        self.assertLess(wildcard, text_plain)
+        self.assertLess(wildcard, text_wildcard)
 
     def test_subtype_wildcard_is_less_than_concrete_types(self) -> None:
-        self.assertLess(
-            ContentType('application', '*'), ContentType('application', 'json')
-        )
-        self.assertLess(
-            ContentType('text', '*'), ContentType('application', 'json')
-        )
+        app_wildcard = datastructures.ContentType('application', '*')
+        app_json = datastructures.ContentType('application', 'json')
+        text_wildcard = datastructures.ContentType('text', '*')
+        self.assertLess(app_wildcard, app_json)
+        self.assertLess(text_wildcard, app_json)
 
     def test_type_with_fewer_parameters_is_lesser(self) -> None:
-        self.assertLess(
-            ContentType('application', 'text', parameters={'1': 1}),
-            ContentType(
-                'application',
-                'text',
-                parameters={
-                    '1': 1,
-                    '2': 2,
-                },
-            ),
+        ct1 = datastructures.ContentType(
+            'application', 'text', parameters={'1': 1}
         )
+        ct2 = datastructures.ContentType(
+            'application', 'text', parameters={'1': 1, '2': 2}
+        )
+        self.assertLess(ct1, ct2)
 
     def test_otherwise_equal_types_ordered_by_primary(self) -> None:
-        self.assertLess(
-            ContentType('first', 'one', parameters={'1': 1}),
-            ContentType('second', 'one', parameters={'1': 1}),
-        )
+        ct1 = datastructures.ContentType('first', 'one', parameters={'1': 1})
+        ct2 = datastructures.ContentType('second', 'one', parameters={'1': 1})
+        self.assertLess(ct1, ct2)
 
     def test_otherwise_equal_types_ordered_by_subtype(self) -> None:
-        self.assertLess(
-            ContentType('application', 'first', parameters={'1': 1}),
-            ContentType('application', 'second', parameters={'1': 1}),
+        ct1 = datastructures.ContentType(
+            'application', 'first', parameters={'1': 1}
         )
+        ct2 = datastructures.ContentType(
+            'application', 'second', parameters={'1': 1}
+        )
+        self.assertLess(ct1, ct2)
 
     def test_comparing_with_strings(self) -> None:
-        content_type = ContentType('text', 'plain')
-        self.assertEqual(content_type, 'text/plain')
+        content_type = datastructures.ContentType('text', 'plain')
+        self.assertEqual('text/plain', content_type)
         self.assertGreater(content_type, 'application/json')
-        self.assertNotEqual(ContentType('text', 'plain'), 'text')
+        text_plain = datastructures.ContentType('text', 'plain')
+        self.assertNotEqual(text_plain, 'text')
 
     def test_comparing_non_content_type_instances(self) -> None:
-        self.assertNotEqual(ContentType('application', 'binary'), object())
-        ct = ContentType('application', 'binary')
+        ct = datastructures.ContentType('application', 'binary')
+        obj = object()
+        self.assertNotEqual(ct, obj)
         for cmp in ('eq', 'ne', 'lt', 'le', 'gt', 'ge'):
             dunder = f'__{cmp}__'
             self.assertIs(
-                getattr(ct, dunder)(object()),
+                getattr(ct, dunder)(obj),
                 NotImplemented,
                 f'{dunder} should return NotImplemented for other type',
             )

--- a/tests/test_datastructure.py
+++ b/tests/test_datastructure.py
@@ -110,6 +110,12 @@ class ContentTypeComparisonTests(unittest.TestCase):
             ContentType('application', 'second', parameters={'1': 1}),
         )
 
+    def test_comparing_with_strings(self) -> None:
+        content_type = ContentType('text', 'plain')
+        self.assertEqual(content_type, 'text/plain')
+        self.assertGreater(content_type, 'application/json')
+        self.assertNotEqual(ContentType('text', 'plain'), 'text')
+
     def test_comparing_non_content_type_instances(self) -> None:
         self.assertNotEqual(ContentType('application', 'binary'), object())
         ct = ContentType('application', 'binary')

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,38 @@
+import unittest
+
+from ietfparse import _helpers, datastructures
+
+
+class ParseHeaderTests(unittest.TestCase):
+    def test_parse_accept_header(self) -> None:
+        result = _helpers.parse_header(
+            'parse_accept', 'text/html, text/plain;q=0.5'
+        )
+        self.assertEqual(len(result), 2)
+        self.assertIsInstance(result[0], datastructures.ContentType)
+        self.assertEqual(str(result[0]), 'text/html')
+        self.assertEqual(str(result[1]), 'text/plain')
+
+    def test_parse_content_type_header(self) -> None:
+        result = _helpers.parse_header(
+            'parse_content_type', 'text/html; charset=utf-8'
+        )
+        self.assertIsInstance(result, datastructures.ContentType)
+        self.assertEqual(str(result), 'text/html; charset=utf-8')
+
+    def test_parse_link_header(self) -> None:
+        result = _helpers.parse_header(
+            'parse_link', '<http://example.com>; rel="next"'
+        )
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], datastructures.LinkHeader)
+        self.assertEqual(result[0].target, 'http://example.com')
+        self.assertEqual(result[0].rel, 'next')
+
+    def test_unknown_parser_raises_error(self) -> None:
+        with self.assertRaises(NotImplementedError):
+            _helpers.parse_header('unknown_parser', 'some value')  # type: ignore[call-overload]
+
+    def test_invalid_value_returns_original(self) -> None:
+        result = _helpers.parse_header('parse_content_type', 'invalid value')
+        self.assertEqual(result, 'invalid value')


### PR DESCRIPTION
Parsing the accept header and content type parameters to `select_content_type` is a good example of _busy work_. The function was changed to accept the string representations along with pre-parsed datastructures. Of course, there is a performance penalty associated with continually reparsing the "available" list so you should pass a list of `ContentType` instances instead of strings there. I added the `ietfparse.constants` module to make this a little easier.