### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,6 @@ mkdocs:
   configuration: "mkdocs-rtd.yml"
 python:
   install:
+    - requirements: docs/requirements.txt
     - method: "pip"
       path: "."
-      extra_requirements:
-        - "dev"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs-material>=9.5.42,<10
+mkdocstrings[python]>=0.26,<0.27
+pymdown-ietflinks==0.0.0


### PR DESCRIPTION
When I removed support for `pip install .[docs]` I broke the readthedocs build :(